### PR TITLE
`<Card>`コンポーネントの作成

### DIFF
--- a/src/components/Card/Card.story.tsx
+++ b/src/components/Card/Card.story.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
-import { Card } from './index';
+
+import { Card, MotionCard } from './index';
 import { Button } from '@/components/Button';
 
 type Story = ComponentStoryObj<typeof Card>;
@@ -32,5 +33,15 @@ export const CustomContent: Story = {
     <Card className="max-w-sm" {...args}>
       <h1 className="font-branding text-3xl font-bold">カードの題名です</h1>カードの内容です<Button>ボタン</Button>
     </Card>
+  ),
+};
+
+export const WithEnteringAnimation: Story = {
+  render: () => (
+    <MotionCard initial={{ opacity: 0, scale: 1.2 }} whileInView={{ opacity: 1, scale: 1.0 }} className="max-w-sm">
+      <h1 className="font-branding text-3xl font-bold">ふわっと出現</h1>
+      {'<MotionCard>でアニメーションを施しています。'}
+      <Button>ボタン</Button>
+    </MotionCard>
   ),
 };

--- a/src/components/Card/Card.story.tsx
+++ b/src/components/Card/Card.story.tsx
@@ -1,0 +1,36 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+import { Card } from './index';
+import { Button } from '@/components/Button';
+
+type Story = ComponentStoryObj<typeof Card>;
+
+const meta: ComponentMeta<typeof Card> = {
+  component: Card,
+  argTypes: {
+    className: {
+      description: 'スタイル上書き用。子のレイアウト変更用途のみに使用することが望ましい。',
+      control: { type: 'text' },
+    },
+    children: {
+      description: 'このカードのコンテンツとなる子要素を指定できる。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    children: 'あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。',
+  },
+};
+
+export const CustomContent: Story = {
+  render: (args) => (
+    <Card className="max-w-sm" {...args}>
+      <h1 className="font-branding text-3xl font-bold">カードの題名です</h1>カードの内容です<Button>ボタン</Button>
+    </Card>
+  ),
+};

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,0 +1,26 @@
+import { motion } from 'framer-motion';
+import type { FC, ComponentPropsWithRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import twMerge from '@/libs/twmerge';
+
+export type CardProps = ComponentPropsWithRef<'div'> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+// `framer-motion`でアニメーションを付加できるようにするため`forwardRef`でrefを受け取れるようにする
+// 型推論はできているのに`<HTMLDivElement, CardProps>`で明示的に型ジェネリクスを指定しないとeslint`react/prop-types`エラーになるため指定
+export const Card: FC<CardProps> = forwardRef<HTMLDivElement, CardProps>(({ className, children, ...props }, ref) => (
+  <div ref={ref} className={twMerge('rounded-3xl shadow-xl bg-white', className)} {...props}>
+    {children}
+  </div>
+));
+
+Card.displayName = 'Card';
+Card.defaultProps = {
+  className: '',
+  children: null,
+};
+
+// `framer-motion`でアニメーション可能なCardコンポーネント
+export const MotionCard = motion(Card);

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -11,7 +11,7 @@ export type CardProps = ComponentPropsWithRef<'div'> & {
 // `framer-motion`でアニメーションを付加できるようにするため`forwardRef`でrefを受け取れるようにする
 // 型推論はできているのに`<HTMLDivElement, CardProps>`で明示的に型ジェネリクスを指定しないとeslint`react/prop-types`エラーになるため指定
 export const Card: FC<CardProps> = forwardRef<HTMLDivElement, CardProps>(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={twMerge('rounded-3xl shadow-xl bg-white', className)} {...props}>
+  <div ref={ref} className={twMerge('rounded-3xl shadow-md bg-white p-4 flex flex-col gap-2', className)} {...props}>
     {children}
   </div>
 ));

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -11,7 +11,7 @@ export type CardProps = ComponentPropsWithRef<'div'> & {
 // `framer-motion`でアニメーションを付加できるようにするため`forwardRef`でrefを受け取れるようにする
 // 型推論はできているのに`<HTMLDivElement, CardProps>`で明示的に型ジェネリクスを指定しないとeslint`react/prop-types`エラーになるため指定
 export const Card: FC<CardProps> = forwardRef<HTMLDivElement, CardProps>(({ className, children, ...props }, ref) => (
-  <div ref={ref} className={twMerge('rounded-3xl shadow-md bg-white p-4 flex flex-col gap-2', className)} {...props}>
+  <div ref={ref} className={twMerge('rounded-base shadow-z8 bg-white p-4 flex flex-col gap-2', className)} {...props}>
     {children}
   </div>
 ));


### PR DESCRIPTION
- close #26 
# 概要
コンテンツを内包するのに繰り返し使い回されるであろう`Card`を作成した。
説明に書いてある`className`の使い方の制約はほぼ気にしなくていい..
# ストーリー
![image](https://user-images.githubusercontent.com/16751535/188553032-620f24fc-24e1-424a-880d-319ea00c07e3.png)
![image](https://user-images.githubusercontent.com/16751535/188553072-4b5be349-ebe8-4f54-a56a-40c85967e67a.png)
