### PR TITLE
`<NavigationMenu>`と関連コンポーネント群`<NavigationItem>` `<NavigationTrigger>` `<NavigationContent>` `<NavigationLink>`の作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.0",
+    "@radix-ui/react-navigation-menu": "^1.0.0",
     "@urql/devtools": "^2.0.3",
     "@urql/exchange-auth": "^1.0.0",
     "daisyui": "^2.24.0",

--- a/src/components/Button/Button.story.tsx
+++ b/src/components/Button/Button.story.tsx
@@ -32,6 +32,10 @@ const meta: ComponentMeta<typeof Button> = {
       description: 'ボタンの見た目を枠線と白抜きの背景にする',
       control: { type: 'boolean' },
     },
+    ghost: {
+      description: 'ボタンの背景等を透明にする',
+      control: { type: 'boolean' },
+    },
     circle: {
       description: 'ボタンを円形化する',
       control: { type: 'boolean' },

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,10 +7,11 @@ export type ButtonProps = ComponentPropsWithoutRef<'button'> &
   MotionProps & {
     type?: 'button' | 'submit';
     outlined?: boolean;
+    ghost?: boolean;
     circle?: boolean;
   };
 
-const Button: FC<ButtonProps> = ({ type, outlined, circle, className, children, ...props }) => {
+const Button: FC<ButtonProps> = ({ type, outlined, ghost, circle, className, children, ...props }) => {
   //
   // https://github.com/jsx-eslint/eslint-plugin-react/issues/1555
   // react/button-has-type は<button>のtype属性の動的割当を禁止しているが、<button>を拡張する際でもアクセシビリティを考慮しtype属性を割り当てるべき。
@@ -27,9 +28,10 @@ const Button: FC<ButtonProps> = ({ type, outlined, circle, className, children, 
           whileTap={{ scale: props.disabled ? 1.0 : 0.95 }}
           type="button"
           className={twMerge(
-            'flex flex-row items-center justify-center gap-2 rounded-base px-4 py-2 font-branding bg-neutral-900 text-white text-base font-bold shadow-z16 hover:shadow-z24 active:shadow-none disabled:shadow-none disabled:contrast-50',
+            'flex flex-row items-center justify-center gap-2 rounded-base px-4 py-2 font-branding bg-neutral-900 text-white text-base font-bold  disabled:contrast-50',
             outlined && 'border-2 border-neutral-200 bg-white text-neutral-900',
             circle && 'rounded-full aspect-square p-2',
+            ghost ? 'border-none bg-transparent text-neutral-900 shadow-none' : 'shadow-z16 hover:shadow-z24 active:shadow-none disabled:shadow-none',
             className,
           )}
           {...props}
@@ -51,6 +53,7 @@ const Button: FC<ButtonProps> = ({ type, outlined, circle, className, children, 
             'flex flex-row items-center justify-center gap-2 rounded-base px-4 py-2 font-branding bg-neutral-900 text-white text-base font-bold shadow-z16 hover:shadow-z24 active:shadow-none disabled:shadow-none disabled:contrast-50',
             outlined && 'border-2 border-neutral-200 bg-white text-neutral-900',
             circle && 'rounded-full aspect-square',
+            ghost && 'border-none bg-transparent text-neutral-900 shadow-none hover:shadow-none',
             className,
           )}
           {...props}
@@ -77,6 +80,7 @@ const ButtonIcon: FC<{ children: ReactNode }> = ({ children }) => {
 Button.defaultProps = {
   type: 'button',
   outlined: false,
+  ghost: false,
   circle: false,
 };
 

--- a/src/components/Navigation/Navigation.story.tsx
+++ b/src/components/Navigation/Navigation.story.tsx
@@ -2,7 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { NavigationMenu, NavigationViewport, NavigationList, NavigationItem, NavigationTrigger, NavigationContent, NavigationLink } from '.';
+import { NavigationMenu, NavigationItem, NavigationTrigger, NavigationContent, NavigationLink } from '.';
 import { Button } from '@/components/Button';
 import { Icon } from '@/components/Icon';
 
@@ -11,24 +11,15 @@ type Story = ComponentStoryObj<typeof NavigationMenu>;
 const meta: ComponentMeta<typeof NavigationMenu> = {
   component: NavigationMenu,
   argTypes: {
-    defaultValue: {
-      description: 'このナビゲーションバーの中で、初期状態のときに選ばれる項目`<NavigationItem>`の`value`を指定できる。',
-      control: { type: 'text' },
-    },
-    value: {
-      description:
-        'このナビゲーションバーの中で、現在選ばれている項目`<NavigationItem>`の`value`を指定する。これを`props`に設定する場合は、`onValueChange`とともに設定する必要がある。',
-      control: { type: 'text' },
-    },
-    onValueChange: {
-      description:
-        'このナビゲーションバーの中で、現在選ばれている項目`<NavigationItem>`が変わろうとしているときに、その`value`を受け取り呼び出されるイベントハンドラを指定する。これを`props`に設定する場合は、`value`とともに設定する必要がある。',
-      control: { type: 'none' },
-    },
     className: {
       description:
-        'ナヴィゲーションバーの項目`<NavigationItem>`を持ち並べている親要素のスタイルを変更するために、`gap-4`等のクラス名を与えることができる。',
-      control: { type: 'none' },
+        'ナヴィゲーションバーの項目`<NavigationItem>`を持ち並べている親要素のスタイルを変更するために、`gap-4`等のクラス名を与えることができる。**吹き出しメニューの表示位置の基準をこのコンポーネントと定めている`position: relative`の設定は上書きしないでください。**',
+      control: { type: 'text' },
+    },
+    viewportClassName: {
+      description:
+        '選択されている項目の吹き出しメニュー`<NavigationContent>`を挿入する先の親要素のスタイルを変更するために使用できる。例えば、`left: 0; justify-content: start;` `right: 0; justify-content: end;`を設定することで、吹き出しメニューのよる方向を変更できる。また、親である`<NavigationMenu>`の幅よりも大きい`width`を設定したい場合にも`w-48`等で使用できる。',
+      control: { type: 'text' },
     },
     children: {
       description: 'このナヴィゲーションバーが持つ項目となる子要素を`<NavigationItem>`を与えることにより指定できる。',
@@ -40,56 +31,49 @@ const meta: ComponentMeta<typeof NavigationMenu> = {
 export default meta;
 
 export const Default: Story = {
+  args: {
+    className: 'justify-center bg-white',
+    viewportClassName: '',
+  },
   render: (args) => (
     <NavigationMenu {...args}>
-      <NavigationList className="justify-center bg-white">
-        <NavigationItem value="game">
-          <NavigationTrigger>
-            <div className="flex px-4 py-2 font-bold">Games</div>
-          </NavigationTrigger>
-          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-game">
-            Xeno, Ice Raze, 大富豪などの6種のゲームで遊びましょう！
-          </NavigationContent>
-        </NavigationItem>
-        <NavigationItem value="ranking">
-          <NavigationTrigger>
-            <div className="flex px-4 py-2 font-bold">Ranking</div>
-          </NavigationTrigger>
-          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-ranking">あなたの順位がわかります！</NavigationContent>
-        </NavigationItem>
-        <NavigationItem value="exchange">
-          <NavigationTrigger>
-            <div className="flex px-4 py-2 font-bold">Exchange</div>
-          </NavigationTrigger>
-          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-exchange">
-            ゲームで獲得したポイントで、実物の景品と交換しましょう！
-          </NavigationContent>
-        </NavigationItem>
-        <NavigationItem value="staff">
-          <NavigationLink>
-            <div className="flex px-4 py-2 font-bold">Staff</div>
-          </NavigationLink>
-        </NavigationItem>
-      </NavigationList>
-      <NavigationViewport />
+      <NavigationItem>
+        <NavigationTrigger>
+          <div className="flex px-4 py-2 font-bold">Games</div>
+        </NavigationTrigger>
+        <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-game">
+          Xeno, Ice Raze, 大富豪などの6種のゲームで遊びましょう！
+        </NavigationContent>
+      </NavigationItem>
+      <NavigationItem>
+        <NavigationTrigger>
+          <div className="flex px-4 py-2 font-bold">Ranking</div>
+        </NavigationTrigger>
+        <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-ranking">あなたの順位がわかります！</NavigationContent>
+      </NavigationItem>
+      <NavigationItem>
+        <NavigationLink>
+          <div className="flex px-4 py-2 font-bold">Staff</div>
+        </NavigationLink>
+      </NavigationItem>
     </NavigationMenu>
   ),
 };
 
 export const IconMenu: Story = {
+  args: {
+    viewportClassName: 'left-0 justify-start w-48',
+  },
   render: (args) => (
     <NavigationMenu {...args}>
-      <NavigationList>
-        <NavigationItem value="user">
-          <NavigationTrigger>
-            <Button ghost className="p-0">
-              <Icon src="/icons/fox.png" />
-            </Button>
-          </NavigationTrigger>
-          <NavigationContent>ユーザーの情報を確認しましょう。</NavigationContent>
-        </NavigationItem>
-      </NavigationList>
-      <NavigationViewport className="w-72 max-w-sm" />
+      <NavigationItem>
+        <NavigationTrigger>
+          <Button ghost className="p-0">
+            <Icon src="/icons/fox.png" />
+          </Button>
+        </NavigationTrigger>
+        <NavigationContent>ユーザーの情報を確認しましょう。</NavigationContent>
+      </NavigationItem>
     </NavigationMenu>
   ),
 };

--- a/src/components/Navigation/Navigation.story.tsx
+++ b/src/components/Navigation/Navigation.story.tsx
@@ -1,0 +1,95 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { NavigationMenu, NavigationViewport, NavigationList, NavigationItem, NavigationTrigger, NavigationContent, NavigationLink } from '.';
+import { Button } from '@/components/Button';
+import { Icon } from '@/components/Icon';
+
+type Story = ComponentStoryObj<typeof NavigationMenu>;
+
+const meta: ComponentMeta<typeof NavigationMenu> = {
+  component: NavigationMenu,
+  argTypes: {
+    defaultValue: {
+      description: 'このナビゲーションバーの中で、初期状態のときに選ばれる項目`<NavigationItem>`の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    value: {
+      description:
+        'このナビゲーションバーの中で、現在選ばれている項目`<NavigationItem>`の`value`を指定する。これを`props`に設定する場合は、`onValueChange`とともに設定する必要がある。',
+      control: { type: 'text' },
+    },
+    onValueChange: {
+      description:
+        'このナビゲーションバーの中で、現在選ばれている項目`<NavigationItem>`が変わろうとしているときに、その`value`を受け取り呼び出されるイベントハンドラを指定する。これを`props`に設定する場合は、`value`とともに設定する必要がある。',
+      control: { type: 'none' },
+    },
+    className: {
+      description:
+        'ナヴィゲーションバーの項目`<NavigationItem>`を持ち並べている親要素のスタイルを変更するために、`gap-4`等のクラス名を与えることができる。',
+      control: { type: 'none' },
+    },
+    children: {
+      description: 'このナヴィゲーションバーが持つ項目となる子要素を`<NavigationItem>`を与えることにより指定できる。',
+      control: { type: 'none' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  render: (args) => (
+    <NavigationMenu {...args}>
+      <NavigationList className="justify-center bg-white">
+        <NavigationItem value="game">
+          <NavigationTrigger>
+            <div className="flex px-4 py-2 font-bold">Games</div>
+          </NavigationTrigger>
+          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-game">
+            Xeno, Ice Raze, 大富豪などの6種のゲームで遊びましょう！
+          </NavigationContent>
+        </NavigationItem>
+        <NavigationItem value="ranking">
+          <NavigationTrigger>
+            <div className="flex px-4 py-2 font-bold">Ranking</div>
+          </NavigationTrigger>
+          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-ranking">あなたの順位がわかります！</NavigationContent>
+        </NavigationItem>
+        <NavigationItem value="exchange">
+          <NavigationTrigger>
+            <div className="flex px-4 py-2 font-bold">Exchange</div>
+          </NavigationTrigger>
+          <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-exchange">
+            ゲームで獲得したポイントで、実物の景品と交換しましょう！
+          </NavigationContent>
+        </NavigationItem>
+        <NavigationItem value="staff">
+          <NavigationLink>
+            <div className="flex px-4 py-2 font-bold">Staff</div>
+          </NavigationLink>
+        </NavigationItem>
+      </NavigationList>
+      <NavigationViewport />
+    </NavigationMenu>
+  ),
+};
+
+export const IconMenu: Story = {
+  render: (args) => (
+    <NavigationMenu {...args}>
+      <NavigationList>
+        <NavigationItem value="user">
+          <NavigationTrigger>
+            <Button ghost className="p-0">
+              <Icon src="/icons/fox.png" />
+            </Button>
+          </NavigationTrigger>
+          <NavigationContent>ユーザーの情報を確認しましょう。</NavigationContent>
+        </NavigationItem>
+      </NavigationList>
+      <NavigationViewport className="w-72 max-w-sm" />
+    </NavigationMenu>
+  ),
+};

--- a/src/components/Navigation/Navigation.story.tsx
+++ b/src/components/Navigation/Navigation.story.tsx
@@ -39,7 +39,11 @@ export const Default: Story = {
     <NavigationMenu {...args}>
       <NavigationItem>
         <NavigationTrigger>
-          <div className="flex px-4 py-2 font-bold">Games</div>
+          <div className="flex px-4 py-2 font-bold">
+            <NavigationLink>
+              <a href="https://example.com/">Games</a>
+            </NavigationLink>
+          </div>
         </NavigationTrigger>
         <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-game">
           Xeno, Ice Raze, 大富豪などの6種のゲームで遊びましょう！
@@ -47,13 +51,19 @@ export const Default: Story = {
       </NavigationItem>
       <NavigationItem>
         <NavigationTrigger>
-          <div className="flex px-4 py-2 font-bold">Ranking</div>
+          <div className="flex px-4 py-2 font-bold">
+            <NavigationLink>
+              <a href="https://example.com/">Ranking</a>
+            </NavigationLink>
+          </div>
         </NavigationTrigger>
         <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-ranking">あなたの順位がわかります！</NavigationContent>
       </NavigationItem>
       <NavigationItem>
         <NavigationLink>
-          <div className="flex px-4 py-2 font-bold">Staff</div>
+          <div className="flex px-4 py-2 font-bold">
+            <a href="https://example.com/">Staff</a>
+          </div>
         </NavigationLink>
       </NavigationItem>
     </NavigationMenu>
@@ -72,7 +82,12 @@ export const IconMenu: Story = {
             <Icon src="/icons/fox.png" />
           </Button>
         </NavigationTrigger>
-        <NavigationContent>ユーザーの情報を確認しましょう。</NavigationContent>
+        <NavigationContent>
+          ユーザーの情報を確認しましょう。
+          <NavigationLink>
+            <a href="https://example.com/">リンク</a>
+          </NavigationLink>
+        </NavigationContent>
       </NavigationItem>
     </NavigationMenu>
   ),

--- a/src/components/Navigation/Navigation.story.tsx
+++ b/src/components/Navigation/Navigation.story.tsx
@@ -1,5 +1,4 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
 import { NavigationMenu, NavigationItem, NavigationTrigger, NavigationContent, NavigationLink } from '.';

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,0 +1,72 @@
+import * as NavigationMenu from '@radix-ui/react-navigation-menu';
+import { AnimatePresence } from 'framer-motion';
+import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import type { ButtonProps } from '@/components/Button';
+import { MotionCard, MotionCardProps } from '@/components/Card';
+import twMerge from '@/libs/twmerge';
+
+export type NavigationLinkProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Link>, 'asChild'> & {
+  children: ReactNode;
+};
+
+// `<NavigationMenu>`のなかで使用するリンク用のラッパーコンポーネント
+export const NavigationLink: FC<NavigationLinkProps> = ({ children, ...props }) => (
+  <NavigationMenu.Link asChild {...props}>
+    {children}
+  </NavigationMenu.Link>
+);
+
+export type NavigationTriggerProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Trigger>, 'asChild'> & {
+  children: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
+};
+
+// `<NavigationItem>`のなかで使用する、吹き出しメニューを開くトリガーとなるボタン用のラッパーコンポーネント
+export const NavigationTrigger: FC<NavigationTriggerProps> = ({ children, ...props }) => (
+  <NavigationMenu.Trigger asChild {...props}>
+    {children}
+  </NavigationMenu.Trigger>
+);
+
+export type NavigationContentProps = MotionCardProps;
+
+// `<NavigationItem>`のなかで使用する、吹き出しメニューの中身用のコンポーネント
+export const NavigationContent: FC<NavigationContentProps> = ({ className, children, ...props }) => (
+  <NavigationMenu.Content asChild>
+    <MotionCard
+      initial={{ opacity: 0, scale: 1.2 }}
+      animate={{ opacity: 1, scale: 1.0 }}
+      exit={{ opacity: 0, scale: 0.8 }}
+      className={className}
+      {...props}
+    >
+      {children}
+    </MotionCard>
+  </NavigationMenu.Content>
+);
+
+export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Item>, 'asChild' | 'children'> &
+  (
+    | {
+        // 吹き出しメニューが持つ場合の子要素。`<NavigationTrigger>`と`<NavigationContent>`を持つ。
+        children: Array<ReactElement<NavigationTriggerProps> | ReactElement<NavigationContentProps>>;
+      }
+    | {
+        // 吹き出しメニューがなく、リンクがそのまま露出している場合の子要素。`<NavigationLink>`のみを受け取る。
+        children: ReactElement<NavigationLinkProps>;
+      }
+  );
+
+export const NavigationItem: FC<NavigationItemProps> = ({ children, ...props }) => <NavigationMenu.Item {...props}>{children}</NavigationMenu.Item>;
+
+export type NavigationListProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Root>, 'children'> & {
+  // `<NavigationList>`は一つ以上の`<NavigationItemProps>`しか子要素として受け取ることができない。
+  children: Array<ReactElement<NavigationItemProps>>;
+};
+
+export const NavigationList: FC<NavigationListProps> = ({ className, children, ...props }) => (
+  <NavigationMenu.Root {...props}>
+    <AnimatePresence>
+      <NavigationMenu.List className={twMerge('flex flex-row gap-0 p-0', className)}>{children}</NavigationMenu.List>
+    </AnimatePresence>
+  </NavigationMenu.Root>
+);

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,50 +1,45 @@
-import * as NavigationMenu from '@radix-ui/react-navigation-menu';
-import { AnimatePresence } from 'framer-motion';
+import * as PrimitiveNavMenu from '@radix-ui/react-navigation-menu';
+import { motion, AnimatePresence } from 'framer-motion';
 import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
-import type { ButtonProps } from '@/components/Button';
 import { MotionCard, MotionCardProps } from '@/components/Card';
 import twMerge from '@/libs/twmerge';
 
-export type NavigationLinkProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Link>, 'asChild'> & {
+export type NavigationLinkProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Link>, 'asChild'> & {
   children: ReactNode;
 };
 
-// `<NavigationMenu>`のなかで使用するリンク用のラッパーコンポーネント
+// `<PrimitiveNavMenu>`のなかで使用するリンク用のラッパーコンポーネント
 export const NavigationLink: FC<NavigationLinkProps> = ({ children, ...props }) => (
-  <NavigationMenu.Link asChild {...props}>
+  <PrimitiveNavMenu.Link asChild {...props}>
     {children}
-  </NavigationMenu.Link>
+  </PrimitiveNavMenu.Link>
 );
 
-export type NavigationTriggerProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Trigger>, 'asChild'> & {
-  children: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
+export type NavigationTriggerProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Trigger>, 'asChild'> & {
+  children: ReactElement;
 };
 
 // `<NavigationItem>`のなかで使用する、吹き出しメニューを開くトリガーとなるボタン用のラッパーコンポーネント
 export const NavigationTrigger: FC<NavigationTriggerProps> = ({ children, ...props }) => (
-  <NavigationMenu.Trigger asChild {...props}>
+  <PrimitiveNavMenu.Trigger asChild {...props}>
     {children}
-  </NavigationMenu.Trigger>
+  </PrimitiveNavMenu.Trigger>
 );
+
+const MotionPrimitiveNavMenuContent = motion(PrimitiveNavMenu.Content);
 
 export type NavigationContentProps = MotionCardProps;
 
 // `<NavigationItem>`のなかで使用する、吹き出しメニューの中身用のコンポーネント
 export const NavigationContent: FC<NavigationContentProps> = ({ className, children, ...props }) => (
-  <NavigationMenu.Content asChild>
-    <MotionCard
-      initial={{ opacity: 0, scale: 1.2 }}
-      animate={{ opacity: 1, scale: 1.0 }}
-      exit={{ opacity: 0, scale: 0.8 }}
-      className={className}
-      {...props}
-    >
+  <MotionPrimitiveNavMenuContent asChild>
+    <MotionCard initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={twMerge('', className)} {...props}>
       {children}
     </MotionCard>
-  </NavigationMenu.Content>
+  </MotionPrimitiveNavMenuContent>
 );
 
-export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Item>, 'asChild' | 'children'> &
+export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Item>, 'asChild' | 'children'> &
   (
     | {
         // 吹き出しメニューが持つ場合の子要素。`<NavigationTrigger>`と`<NavigationContent>`を持つ。
@@ -56,17 +51,34 @@ export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof Navigatio
       }
   );
 
-export const NavigationItem: FC<NavigationItemProps> = ({ children, ...props }) => <NavigationMenu.Item {...props}>{children}</NavigationMenu.Item>;
+export const NavigationItem: FC<NavigationItemProps> = ({ children, ...props }) => (
+  <PrimitiveNavMenu.Item {...props}>{children}</PrimitiveNavMenu.Item>
+);
 
-export type NavigationListProps = Omit<ComponentPropsWithoutRef<typeof NavigationMenu.Root>, 'children'> & {
+export type NavigationListProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.List>, 'asChild' | 'children'> & {
   // `<NavigationList>`は一つ以上の`<NavigationItemProps>`しか子要素として受け取ることができない。
-  children: Array<ReactElement<NavigationItemProps>>;
+  children: Array<ReactElement<NavigationItemProps>> | ReactElement<NavigationItemProps>;
 };
 
 export const NavigationList: FC<NavigationListProps> = ({ className, children, ...props }) => (
-  <NavigationMenu.Root {...props}>
-    <AnimatePresence>
-      <NavigationMenu.List className={twMerge('flex flex-row gap-0 p-0', className)}>{children}</NavigationMenu.List>
-    </AnimatePresence>
-  </NavigationMenu.Root>
+  <PrimitiveNavMenu.List className={twMerge('flex flex-row gap-0 m-0 p-0', className)} {...props}>
+    {children}
+  </PrimitiveNavMenu.List>
+);
+
+export type NavigationViewportProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Viewport>, 'asChild'>;
+
+// `<NavigationMenu>`のなかで使用する、吹き出しメニューの表示位置を制御するコンポーネント。この子孫として`<NavigationContent>`が配置される。
+export const NavigationViewport: FC<NavigationViewportProps> = ({ className, ...props }) => (
+  <PrimitiveNavMenu.Viewport className={twMerge('absolute top-full origin-top mt-2 w-full', className)} {...props} />
+);
+
+export type PrimitiveNavMenuProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Root>, 'asChild' | 'children'> & {
+  children: Array<ReactElement<NavigationListProps> | ReactElement<NavigationViewportProps>> | ReactElement<NavigationListProps>;
+};
+
+export const NavigationMenu: FC<PrimitiveNavMenuProps> = ({ children, ...props }) => (
+  <PrimitiveNavMenu.Root className="relative z-10 w-fit" {...props}>
+    {children}
+  </PrimitiveNavMenu.Root>
 );

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,5 +1,4 @@
 import * as PrimitiveNavMenu from '@radix-ui/react-navigation-menu';
-import { motion, AnimatePresence } from 'framer-motion';
 import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
 import { MotionCard, MotionCardProps } from '@/components/Card';
 import twMerge from '@/libs/twmerge';
@@ -8,7 +7,7 @@ export type NavigationLinkProps = Omit<ComponentPropsWithoutRef<typeof Primitive
   children: ReactNode;
 };
 
-// `<PrimitiveNavMenu>`のなかで使用するリンク用のラッパーコンポーネント
+// 項目`<NavigationItem>`のなかで使用するリンク用のラッパーコンポーネント
 export const NavigationLink: FC<NavigationLinkProps> = ({ children, ...props }) => (
   <PrimitiveNavMenu.Link asChild {...props}>
     {children}
@@ -19,27 +18,25 @@ export type NavigationTriggerProps = Omit<ComponentPropsWithoutRef<typeof Primit
   children: ReactElement;
 };
 
-// `<NavigationItem>`のなかで使用する、吹き出しメニューを開くトリガーとなるボタン用のラッパーコンポーネント
+// 項目`<NavigationItem>`のなかで使用する、その項目の吹き出しメニューを開くトリガーとなるボタン用のラッパーコンポーネント
 export const NavigationTrigger: FC<NavigationTriggerProps> = ({ children, ...props }) => (
   <PrimitiveNavMenu.Trigger asChild {...props}>
     {children}
   </PrimitiveNavMenu.Trigger>
 );
 
-const MotionPrimitiveNavMenuContent = motion(PrimitiveNavMenu.Content);
-
 export type NavigationContentProps = MotionCardProps;
 
-// `<NavigationItem>`のなかで使用する、吹き出しメニューの中身用のコンポーネント
+// 項目`<NavigationItem>`のなかで使用する、その項目の吹き出しメニューの中身用のコンポーネント
 export const NavigationContent: FC<NavigationContentProps> = ({ className, children, ...props }) => (
-  <MotionPrimitiveNavMenuContent asChild>
-    <MotionCard initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={twMerge('', className)} {...props}>
+  <PrimitiveNavMenu.Content asChild>
+    <MotionCard initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={twMerge('shadow-z16', className)} {...props}>
       {children}
     </MotionCard>
-  </MotionPrimitiveNavMenuContent>
+  </PrimitiveNavMenu.Content>
 );
 
-export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Item>, 'asChild' | 'children'> &
+export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Item>, 'asChild' | 'children' | 'value'> &
   (
     | {
         // 吹き出しメニューが持つ場合の子要素。`<NavigationTrigger>`と`<NavigationContent>`を持つ。
@@ -51,34 +48,28 @@ export type NavigationItemProps = Omit<ComponentPropsWithoutRef<typeof Primitive
       }
   );
 
+// ナヴィゲーションメニューの項目を表すコンポーネント
 export const NavigationItem: FC<NavigationItemProps> = ({ children, ...props }) => (
   <PrimitiveNavMenu.Item {...props}>{children}</PrimitiveNavMenu.Item>
 );
 
-export type NavigationListProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.List>, 'asChild' | 'children'> & {
-  // `<NavigationList>`は一つ以上の`<NavigationItemProps>`しか子要素として受け取ることができない。
+export type PrimitiveNavMenuProps = Omit<
+  ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Root>,
+  'asChild' | 'children' | 'orientation' | 'value' | 'defaultValue' | 'onValueChange'
+> & {
   children: Array<ReactElement<NavigationItemProps>> | ReactElement<NavigationItemProps>;
+  viewportClassName?: string;
 };
 
-export const NavigationList: FC<NavigationListProps> = ({ className, children, ...props }) => (
-  <PrimitiveNavMenu.List className={twMerge('flex flex-row gap-0 m-0 p-0', className)} {...props}>
-    {children}
-  </PrimitiveNavMenu.List>
-);
-
-export type NavigationViewportProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Viewport>, 'asChild'>;
-
-// `<NavigationMenu>`のなかで使用する、吹き出しメニューの表示位置を制御するコンポーネント。この子孫として`<NavigationContent>`が配置される。
-export const NavigationViewport: FC<NavigationViewportProps> = ({ className, ...props }) => (
-  <PrimitiveNavMenu.Viewport className={twMerge('absolute top-full origin-top mt-2 w-full', className)} {...props} />
-);
-
-export type PrimitiveNavMenuProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveNavMenu.Root>, 'asChild' | 'children'> & {
-  children: Array<ReactElement<NavigationListProps> | ReactElement<NavigationViewportProps>> | ReactElement<NavigationListProps>;
-};
-
-export const NavigationMenu: FC<PrimitiveNavMenuProps> = ({ children, ...props }) => (
+export const NavigationMenu: FC<PrimitiveNavMenuProps> = ({ className, viewportClassName, children, ...props }) => (
   <PrimitiveNavMenu.Root className="relative z-10 w-fit" {...props}>
-    {children}
+    <PrimitiveNavMenu.List className={twMerge('flex flex-row gap-0 m-0 p-0', className)}>{children}</PrimitiveNavMenu.List>
+    <PrimitiveNavMenu.Viewport
+      className={twMerge('bg-transparent absolute top-full flex justify-center origin-top mt-2 min-w-fit w-full max-w-sm', viewportClassName)}
+    />
   </PrimitiveNavMenu.Root>
 );
+
+NavigationMenu.defaultProps = {
+  viewportClassName: '',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,17 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-collection@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.0.tgz#0ec4c72fabd35a03b5787075ac799e3b17ca5710"
+  integrity sha512-8i1pf5dKjnq90Z8udnnXKzdCEV3/FYrfw0n/b6NvB6piXEn3fO1bOh7HBcpG8XrnIXzxlYu2oCcR38QpyLS/mg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+
 "@radix-ui/react-compose-refs@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
@@ -2836,6 +2847,13 @@
     "@radix-ui/react-use-controllable-state" "1.0.0"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.4"
+
+"@radix-ui/react-direction@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.0.tgz#a2e0b552352459ecf96342c79949dd833c1e6e45"
+  integrity sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-dismissable-layer@1.0.0":
   version "1.0.0"
@@ -2873,6 +2891,27 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-navigation-menu@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.0.0.tgz#5aaf65967794147eee52e87930191c55d08bd213"
+  integrity sha512-HbwG3A9z9zdcan0076EbTXqMvmQeesC3nOMEL7XtWqBnxPo8MLStk0vMs0hjIQ+9O9/KTcEJq+TeRX2pUuvuSg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-use-previous" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.0"
 
 "@radix-ui/react-portal@1.0.0":
   version "1.0.0"
@@ -2936,6 +2975,21 @@
   integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-previous@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.0.0.tgz#e48a69c3a7d8078a967084038df66d0d181c56ac"
+  integrity sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-visually-hidden@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.0.tgz#4d69d7e3b6d21ee4678ed6de5215dcd068394401"
+  integrity sha512-MwAhMdX+n6S4InwRKSnpUsp+lLkYG6izQF56ul6guSX2mBBLOMV9Frx7xJlkEe2GjKLzbNuHhaCS6e5gopmZNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.0"
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.4"


### PR DESCRIPTION
- close #5 
- close #48 

# 概要
マウスでホバーして一時表示、もしくはクリックでトグル表示できる吹き出しメニューが付随するナヴィゲーションメニューを作成できるコンポーネント群`<NavigationMenu>`を作成した。
吹き出しの表示位置の右寄せ、中央寄せ、左寄せ等の調整は`viewportClassName`属性から吹き出しメニュー`<NavigationContent>`の親要素にスタイルを当てることで実現可能。
# コード例
```tsx
<NavigationMenu className="justify-center bg-white">
      <NavigationItem>
        <NavigationTrigger>
          <div className="flex px-4 py-2 font-bold">
            <NavigationLink>
              <a href="https://example.com/">Games</a>
            </NavigationLink>
          </div>
        </NavigationTrigger>
        <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-game">
          Xeno, Ice Raze, 大富豪などの6種のゲームで遊びましょう！
        </NavigationContent>
      </NavigationItem>
      <NavigationItem>
        <NavigationTrigger>
          <div className="flex px-4 py-2 font-bold">
            <NavigationLink>
              <a href="https://example.com/">Ranking</a>
            </NavigationLink>
          </div>
        </NavigationTrigger>
        <NavigationContent className="bg-gradient-to-br font-bold text-white gradient-ranking">あなたの順位がわかります！</NavigationContent>
      </NavigationItem>
      <NavigationItem>
        <NavigationLink>
          <div className="flex px-4 py-2 font-bold">
            <a href="https://example.com/">Staff</a>
          </div>
        </NavigationLink>
      </NavigationItem>
    </NavigationMenu>
```
![image](https://user-images.githubusercontent.com/16751535/189001278-e76ea732-b646-4f31-ae87-86bf45bfefc0.png)
![image](https://user-images.githubusercontent.com/16751535/189001358-b416add5-655a-4591-8792-8069767a8502.png)
# 詳細
Storybookの`docs`を参照してください！