### PR TITLE
`<Selector>`を始めとするセレクターを提供するコンポーネント群を追加した。

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.0.0",
+    "@radix-ui/react-select": "^1.0.0",
     "@urql/devtools": "^2.0.3",
     "@urql/exchange-auth": "^1.0.0",
     "daisyui": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-label": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.0.0",
     "@radix-ui/react-radio-group": "^1.0.0",
+    "@radix-ui/react-select": "^1.0.0",
     "@urql/devtools": "^2.0.3",
     "@urql/exchange-auth": "^1.0.0",
     "daisyui": "^2.24.0",

--- a/src/components/Selector/Selector.story.tsx
+++ b/src/components/Selector/Selector.story.tsx
@@ -21,18 +21,22 @@ const meta: ComponentMeta<typeof Selector> = {
       description: 'このセレクターで現在選択されている選択肢`<SelectorItem>`の`value`を指定できる。',
       control: { type: 'text' },
     },
-    // onValueChange: {
-    //   description: 'このセレクターで選択される選択肢が変更されるときに、その`value`とともに呼び出されるイベントハンドラを指定できる。',
-    //   control: { type: 'none' },
+    onValueChange: {
+      description: 'このセレクターで選択される選択肢が変更されるときに、その`value`とともに呼び出されるイベントハンドラを指定できる。',
+      control: { type: 'none' },
+    },
+    // defaultOpen: {
+    //   description: 'このセレクターの初期状態での開閉状態を指定できる。',
+    //   control: { type: 'boolean' },
     // },
     // open: {
     //   description: 'このセレクターの開閉状態を指定できる。',
     //   control: { type: 'boolean' },
     // },
-    onOpenChange: {
-      description: 'このセレクターで開閉状態が変更されるときに、その`boolean`とともに呼び出されるイベントハンドラを指定できる。',
-      control: { type: 'none' },
-    },
+    // onOpenChange: {
+    //   description: 'このセレクターで開閉状態が変更されるときに、その`boolean`とともに呼び出されるイベントハンドラを指定できる。',
+    //   control: { type: 'none' },
+    // },
     trigger: {
       description: 'このセレクタのメニューを開くトリガーとなるボタンを指定できる。`<SelectorTrigger>`のみ指定可能。省略可能。',
       control: { type: 'none' },

--- a/src/components/Selector/Selector.story.tsx
+++ b/src/components/Selector/Selector.story.tsx
@@ -1,0 +1,93 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { Selector, SelectorTrigger, SelectorGroup, SelectorItem, SelectorSeparator } from '.';
+import { Button } from '@/components/Button';
+import { Icon } from '@/components/Icon';
+
+type Story = ComponentStoryObj<typeof Selector>;
+
+const meta: ComponentMeta<typeof Selector> = {
+  component: Selector,
+  args: {
+    onValueChange: action('onValueChange'),
+  },
+  argTypes: {
+    defaultValue: {
+      description: 'このセレクターの初期状態の選択肢`<SelectorItem>`の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    value: {
+      description: 'このセレクターで現在選択されている選択肢`<SelectorItem>`の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    // onValueChange: {
+    //   description: 'このセレクターで選択される選択肢が変更されるときに、その`value`とともに呼び出されるイベントハンドラを指定できる。',
+    //   control: { type: 'none' },
+    // },
+    // open: {
+    //   description: 'このセレクターの開閉状態を指定できる。',
+    //   control: { type: 'boolean' },
+    // },
+    onOpenChange: {
+      description: 'このセレクターで開閉状態が変更されるときに、その`boolean`とともに呼び出されるイベントハンドラを指定できる。',
+      control: { type: 'none' },
+    },
+    trigger: {
+      description: 'このセレクタのメニューを開くトリガーとなるボタンを指定できる。`<SelectorTrigger>`のみ指定可能。省略可能。',
+      control: { type: 'none' },
+    },
+    children: {
+      description:
+        "このセレクタを使い選ぶことのできる選択肢を、`<SelectorItem>`を与えることにより指定できる。また、名前付きの選択肢のグループを作成したい場合、`<SelectorGroup label='グループの名前'>`に選択肢を子要素として与えることで実現できる。そして、区切り線を追加するために`<SelectorSeparator>`を使うことができる。",
+      control: { type: 'none' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  render: (args) => (
+    <div>
+      <Selector aria-label="food" {...args}>
+        <SelectorGroup label="くだもの">
+          <SelectorItem value="apple">りんご</SelectorItem>
+          <SelectorItem value="grape">ぶどう</SelectorItem>
+        </SelectorGroup>
+        <SelectorGroup label="野菜">
+          <SelectorItem value="potato">馬鈴薯</SelectorItem>
+          <SelectorItem value="carrot">人参</SelectorItem>
+        </SelectorGroup>
+        <SelectorSeparator />
+        <SelectorItem value="water">お水</SelectorItem>
+        <SelectorItem value="cola">コーラ</SelectorItem>
+      </Selector>
+    </div>
+  ),
+};
+
+export const OptionWithIcon: Story = {
+  render: (args) => (
+    <div>
+      <Selector aria-label="category" {...args}>
+        <SelectorGroup label="日付ごと">
+          <SelectorItem value="day1">一日目のみ</SelectorItem>
+          <SelectorItem value="day2">二日目のみ</SelectorItem>
+        </SelectorGroup>
+        <SelectorSeparator />
+        <SelectorGroup label="使用キャラごと">
+          <SelectorItem value="fox">
+            <Icon src="/icons/fox.png" alt="きゅうびさんの画像" className="h-6" />
+            <span className="font-bold">きゅうびさん</span>のみ
+          </SelectorItem>
+          <SelectorItem value="cat">
+            <Icon src="/icons/cat.png" alt="ねこさんの画像" className="h-6" />
+            <span className="font-bold">ねこさん</span>のみ
+          </SelectorItem>
+        </SelectorGroup>
+      </Selector>
+    </div>
+  ),
+};

--- a/src/components/Selector/Selector.story.tsx
+++ b/src/components/Selector/Selector.story.tsx
@@ -2,8 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { Selector, SelectorTrigger, SelectorGroup, SelectorItem, SelectorSeparator } from '.';
-import { Button } from '@/components/Button';
+import { Selector, SelectorGroup, SelectorItem, SelectorSeparator } from '.';
 import { Icon } from '@/components/Icon';
 
 type Story = ComponentStoryObj<typeof Selector>;

--- a/src/components/Selector/SelectorItem.story.tsx
+++ b/src/components/Selector/SelectorItem.story.tsx
@@ -1,0 +1,49 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { Selector, SelectorTrigger, SelectorGroup, SelectorItem, SelectorSeparator } from '.';
+
+import { Icon } from '@/components/Icon';
+
+type Story = ComponentStoryObj<typeof SelectorItem>;
+
+const meta: ComponentMeta<typeof SelectorItem> = {
+  component: SelectorItem,
+  args: {
+    value: 'apple',
+    disabled: false,
+    children: 'りんご',
+  },
+  argTypes: {
+    value: {
+      description:
+        'この選択肢を識別する固有な文字列を設定できる。選択された時、この値が祖先の`<Selector>`の`onValueChange`イベントハンドラに渡される。もしくは、イベントハンドラが設定されていなかった場合は、そのまま`value`に設定される。',
+      control: { type: 'text' },
+    },
+    disabled: {
+      description: 'この選択肢が選択可能かどうかを指定できる。`true`の場合、選択できず、キーボードでの操作からも除外される。',
+      control: { type: 'boolean' },
+    },
+    children: {
+      description:
+        'この選択肢のラベルを指定できる。スタイルされていないテキストのみが望ましいが、アイコンなども表示することができる。また、これが選択されているときは、セレクタの常時表示部分の`<SelectorTrigger>`の子要素として与えられる。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  render: (args) => (
+    <div>
+      <Selector onValueChange={action('onValueChange')} aria-label="food">
+        <SelectorGroup label="くだもの">
+          <SelectorItem {...args} />
+          <SelectorItem value="grape">ぶどう</SelectorItem>
+        </SelectorGroup>
+      </Selector>
+    </div>
+  ),
+};

--- a/src/components/Selector/SelectorItem.story.tsx
+++ b/src/components/Selector/SelectorItem.story.tsx
@@ -2,9 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { Selector, SelectorTrigger, SelectorGroup, SelectorItem, SelectorSeparator } from '.';
-
-import { Icon } from '@/components/Icon';
+import { Selector, SelectorGroup, SelectorItem } from '.';
 
 type Story = ComponentStoryObj<typeof SelectorItem>;
 

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -1,0 +1,86 @@
+import * as Select from '@radix-ui/react-select';
+import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import { Button } from '@/components/Button';
+import { MotionCard } from '@/components/Card';
+import twMerge from '@/libs/twmerge';
+
+export type SelectorTriggerProps = Omit<ComponentPropsWithoutRef<typeof Select.Trigger>, 'asChild'> &
+  Pick<ComponentPropsWithoutRef<typeof Select.Value>, 'placeholder'> & {
+    children?: ReactNode;
+  };
+
+export const SelectorTrigger: FC<SelectorTriggerProps> = ({ placeholder, className, children, ...props }) => (
+  <Select.Trigger asChild {...props}>
+    <Button className={twMerge('[&[data-placeholder]]:text-neutral-500', className)} outlined>
+      {children}
+      <Select.Value {...{ placeholder }} />
+      <Select.Icon />
+    </Button>
+  </Select.Trigger>
+);
+
+SelectorTrigger.defaultProps = {
+  children: '',
+};
+
+export type SelectorItemProps = Omit<ComponentPropsWithoutRef<typeof Select.Item>, 'asChild'> & {
+  displayName: string;
+  children: ReactNode;
+};
+
+export const SelectorItem: FC<SelectorItemProps> = ({ children, displayName, ...props }) => (
+  <Select.Item className="relative flex flex-row items-center justify-center gap-2 [&[data-disabled]]:text-neutral-500" {...props}>
+    {children}
+    <Select.ItemText>{displayName}</Select.ItemText>
+    <Select.ItemIndicator className="absolute left-0 flex aspect-square h-4 items-center justify-center text-success-700">x</Select.ItemIndicator>
+  </Select.Item>
+);
+
+export type SelectorGroupProps = Omit<ComponentPropsWithoutRef<typeof Select.Group>, 'asChild'> & {
+  label: string;
+  children: Array<ReactElement<SelectorItemProps>>;
+};
+
+export const SelectorGroup: FC<SelectorGroupProps> = ({ children, label, ...props }) => (
+  <Select.Group className="flex flex-col gap-2" {...props}>
+    <Select.Label>{label}</Select.Label>
+    {children}
+  </Select.Group>
+);
+
+export type SelectorSeparatorProps = Record<string, never>;
+
+export const SelectorSeparator: FC = () => <Select.Separator className="my-2 h-px bg-neutral-300" />;
+
+export type SelectorContentProps = Omit<ComponentPropsWithoutRef<typeof Select.Content>, 'asChild'> & {
+  children:
+    | Array<ReactElement<SelectorGroupProps> | ReactElement<SelectorItemProps> | ReactElement<SelectorSeparatorProps>>
+    | ReactElement<SelectorGroupProps>
+    | ReactElement<SelectorItemProps>;
+};
+
+export const SelectorContent: FC<SelectorContentProps> = ({ children, ...props }) => (
+  <Select.Content asChild {...props}>
+    <MotionCard initial={{ opacity: 0, scale: 1.2 }} animate={{ opacity: 1, scale: 1.0 }} exit={{ opacity: 0, scale: 0.8 }}>
+      <Select.ScrollUpButton className="flex h-4 cursor-default items-center justify-center text-neutral-500" />
+      <Select.Viewport>{children}</Select.Viewport>
+      <Select.ScrollDownButton className="flex h-4 cursor-default items-center justify-center text-neutral-500" />
+    </MotionCard>
+  </Select.Content>
+);
+
+export type SelectorProps = Omit<ComponentPropsWithoutRef<typeof Select.Root>, 'asChild' | 'children' | 'open' | 'onOpenChange'> & {
+  trigger?: ReactElement<SelectorTriggerProps>;
+  children: ReactElement<SelectorContentProps>;
+};
+
+export const Selector: FC<SelectorProps> = ({ trigger, children, ...props }) => (
+  <Select.Root {...props}>
+    {trigger}
+    <Select.Portal />
+  </Select.Root>
+);
+
+Selector.defaultProps = {
+  trigger: <SelectorTrigger />,
+};

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -37,7 +37,7 @@ export type SelectorItemProps = Omit<ComponentPropsWithoutRef<typeof Select.Item
 
 export const SelectorItem: FC<SelectorItemProps> = ({ children, ...props }) => (
   <Select.Item
-    className="relative flex flex-row items-center gap-2 overflow-visible rounded-base p-1 pl-8 pr-2 font-branding ring-transparent [&[data-disabled]]:text-neutral-300 [&[data-state='checked']]:bg-primary-100 [&[data-state='checked']]:text-primary-900"
+    className="relative flex flex-row items-center gap-2 overflow-visible rounded-base p-1 pl-8 pr-2 font-branding outline-none ring-transparent [&[data-disabled]]:text-neutral-300 [&[data-state='checked']]:bg-primary-100 [&[data-state='checked']]:text-primary-900 [&[data-highlighted]]:bg-primary-100"
     {...props}
   >
     <Select.ItemText asChild>

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -67,14 +67,13 @@ export const SelectorGroup: FC<SelectorGroupProps> = ({ children, label, ...prop
 
 export type SelectorSeparatorProps = Omit<ComponentPropsWithoutRef<typeof Select.Separator>, 'asChild'>;
 
-// export const SelectorSeparator: FC = (props) => <Select.Separator className="my-1 h-[1px] bg-neutral-200" {...props} />;
 export const SelectorSeparator: FC = (props) => (
   <Select.Separator asChild {...props}>
     <hr className="my-1 h-[1px] bg-neutral-200" />
   </Select.Separator>
 );
 
-export type SelectorProps = Omit<ComponentPropsWithoutRef<typeof Select.Root>, 'asChild' | 'children'> & {
+export type SelectorProps = Omit<ComponentPropsWithoutRef<typeof Select.Root>, 'asChild' | 'children' | 'open' | 'defaultOpen' | 'onOpenChange'> & {
   trigger?: ReactElement<SelectorTriggerProps>;
   children:
     | Array<ReactElement<SelectorGroupProps> | ReactElement<SelectorItemProps> | ReactElement<SelectorSeparatorProps>>

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -1,21 +1,31 @@
 import * as Select from '@radix-ui/react-select';
+import { AnimatePresence } from 'framer-motion';
 import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import { FaChevronUp, FaChevronDown } from 'react-icons/fa';
+import { MdCheck } from 'react-icons/md';
 import { Button } from '@/components/Button';
 import { MotionCard } from '@/components/Card';
 import twMerge from '@/libs/twmerge';
 
 export type SelectorTriggerProps = Omit<ComponentPropsWithoutRef<typeof Select.Trigger>, 'asChild'> &
-  Pick<ComponentPropsWithoutRef<typeof Select.Value>, 'placeholder'> & {
+  Required<Pick<ComponentPropsWithoutRef<typeof Select.Value>, 'placeholder'>> & {
     children?: ReactNode;
   };
 
 export const SelectorTrigger: FC<SelectorTriggerProps> = ({ placeholder, className, children, ...props }) => (
   <Select.Trigger asChild {...props}>
-    <Button className={twMerge('[&[data-placeholder]]:text-neutral-500', className)} outlined>
+    <div
+      className={twMerge(
+        'flex w-fit min-w-[8rem] flex-row items-center justify-center gap-2 rounded-base px-4 py-2 font-branding shadow-z8 bg-white text-neutral-900 text-base font-bold  disabled:contrast-50 [&[data-placeholder]]:text-neutral-400',
+        className,
+      )}
+    >
       {children}
       <Select.Value {...{ placeholder }} />
-      <Select.Icon />
-    </Button>
+      <Select.Icon asChild>
+        <FaChevronDown className="text-neutral-400" />
+      </Select.Icon>
+    </div>
   </Select.Trigger>
 );
 
@@ -24,63 +34,82 @@ SelectorTrigger.defaultProps = {
 };
 
 export type SelectorItemProps = Omit<ComponentPropsWithoutRef<typeof Select.Item>, 'asChild'> & {
-  displayName: string;
-  children: ReactNode;
+  children?: ReactNode;
 };
 
-export const SelectorItem: FC<SelectorItemProps> = ({ children, displayName, ...props }) => (
-  <Select.Item className="relative flex flex-row items-center justify-center gap-2 [&[data-disabled]]:text-neutral-500" {...props}>
-    {children}
-    <Select.ItemText>{displayName}</Select.ItemText>
-    <Select.ItemIndicator className="absolute left-0 flex aspect-square h-4 items-center justify-center text-success-700">x</Select.ItemIndicator>
+export const SelectorItem: FC<SelectorItemProps> = ({ children, ...props }) => (
+  <Select.Item
+    className="relative flex flex-row items-center gap-2 overflow-visible rounded-base p-1 pl-8 pr-2 font-branding ring-transparent [&[data-disabled]]:text-neutral-300 [&[data-state='checked']]:bg-primary-100 [&[data-state='checked']]:text-primary-900"
+    {...props}
+  >
+    <Select.ItemText asChild>
+      <span className="flex flex-row items-center justify-start gap-2">{children}</span>
+    </Select.ItemText>
+    <Select.ItemIndicator className="absolute left-2 flex aspect-square h-4 items-center justify-center text-primary">
+      <MdCheck />
+    </Select.ItemIndicator>
   </Select.Item>
 );
 
+SelectorItem.defaultProps = {
+  children: null,
+};
+
 export type SelectorGroupProps = Omit<ComponentPropsWithoutRef<typeof Select.Group>, 'asChild'> & {
   label: string;
-  children: Array<ReactElement<SelectorItemProps>>;
+  children: Array<ReactElement<SelectorItemProps>> | ReactElement<SelectorItemProps>;
 };
 
 export const SelectorGroup: FC<SelectorGroupProps> = ({ children, label, ...props }) => (
-  <Select.Group className="flex flex-col gap-2" {...props}>
-    <Select.Label>{label}</Select.Label>
+  <Select.Group className="flex flex-col gap-0" {...props}>
+    <Select.Label className="text-xs text-neutral-400">{label}</Select.Label>
     {children}
   </Select.Group>
 );
 
-export type SelectorSeparatorProps = Record<string, never>;
+export type SelectorSeparatorProps = Omit<ComponentPropsWithoutRef<typeof Select.Separator>, 'asChild'>;
 
-export const SelectorSeparator: FC = () => <Select.Separator className="my-2 h-px bg-neutral-300" />;
+// export const SelectorSeparator: FC = (props) => <Select.Separator className="my-1 h-[1px] bg-neutral-200" {...props} />;
+export const SelectorSeparator: FC = (props) => (
+  <Select.Separator asChild {...props}>
+    <hr className="my-1 h-[1px] bg-neutral-200" />
+  </Select.Separator>
+);
 
-export type SelectorContentProps = Omit<ComponentPropsWithoutRef<typeof Select.Content>, 'asChild'> & {
+export type SelectorProps = Omit<ComponentPropsWithoutRef<typeof Select.Root>, 'asChild' | 'children'> & {
+  trigger?: ReactElement<SelectorTriggerProps>;
   children:
     | Array<ReactElement<SelectorGroupProps> | ReactElement<SelectorItemProps> | ReactElement<SelectorSeparatorProps>>
     | ReactElement<SelectorGroupProps>
     | ReactElement<SelectorItemProps>;
 };
 
-export const SelectorContent: FC<SelectorContentProps> = ({ children, ...props }) => (
-  <Select.Content asChild {...props}>
-    <MotionCard initial={{ opacity: 0, scale: 1.2 }} animate={{ opacity: 1, scale: 1.0 }} exit={{ opacity: 0, scale: 0.8 }}>
-      <Select.ScrollUpButton className="flex h-4 cursor-default items-center justify-center text-neutral-500" />
-      <Select.Viewport>{children}</Select.Viewport>
-      <Select.ScrollDownButton className="flex h-4 cursor-default items-center justify-center text-neutral-500" />
-    </MotionCard>
-  </Select.Content>
-);
-
-export type SelectorProps = Omit<ComponentPropsWithoutRef<typeof Select.Root>, 'asChild' | 'children' | 'open' | 'onOpenChange'> & {
-  trigger?: ReactElement<SelectorTriggerProps>;
-  children: ReactElement<SelectorContentProps>;
-};
-
 export const Selector: FC<SelectorProps> = ({ trigger, children, ...props }) => (
   <Select.Root {...props}>
     {trigger}
-    <Select.Portal />
+
+    <Select.Portal>
+      <Select.Content asChild>
+        <MotionCard
+          layout
+          className={twMerge('min-w-fit g-0 mt-2 shadow-z16')}
+          initial={{ opacity: 0, scale: 1.2 }}
+          animate={{ opacity: 1, scale: 1.0 }}
+          exit={{ opacity: 0, scale: 0.8 }}
+        >
+          <Select.ScrollUpButton className="flex h-2 cursor-default items-center justify-center text-neutral-500">
+            <FaChevronUp />
+          </Select.ScrollUpButton>
+          <Select.Viewport className="flex flex-col gap-2">{children}</Select.Viewport>
+          <Select.ScrollDownButton className="flex h-2 cursor-default items-center justify-center text-neutral-500">
+            <FaChevronUp />
+          </Select.ScrollDownButton>
+        </MotionCard>
+      </Select.Content>
+    </Select.Portal>
   </Select.Root>
 );
 
 Selector.defaultProps = {
-  trigger: <SelectorTrigger />,
+  trigger: <SelectorTrigger placeholder="選択してください" />,
 };

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -1,9 +1,7 @@
 import * as Select from '@radix-ui/react-select';
-import { AnimatePresence } from 'framer-motion';
 import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
 import { FaChevronUp, FaChevronDown } from 'react-icons/fa';
 import { MdCheck } from 'react-icons/md';
-import { Button } from '@/components/Button';
 import { MotionCard } from '@/components/Card';
 import twMerge from '@/libs/twmerge';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,6 +2795,13 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@radix-ui/number@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.0.tgz#4c536161d0de750b3f5d55860fc3de46264f897b"
+  integrity sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/primitive@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
@@ -2892,6 +2899,17 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
+"@radix-ui/react-label@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-1.0.0.tgz#c6691b0bec18958512a952c18732279285b61fef"
+  integrity sha512-k+EbxeRaVbSJ4oaR9eUYuC0cDIGRB4TAPhilbFCIMpP9pXFNcyQPQUvRaVOQBrviuArYM80xh0BQR/0y3kjUdQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+
 "@radix-ui/react-navigation-menu@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.0.0.tgz#5aaf65967794147eee52e87930191c55d08bd213"
@@ -2937,6 +2955,34 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.0"
+
+"@radix-ui/react-select@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-1.0.0.tgz#16d91f493a18e471d40fc06b1faff516b5686784"
+  integrity sha512-GfbVBxx7JPvytNT+0XYCFCOImEMmpl0Vg7hhifLaLV7p5zRottFMgQ7qrrxw8v6B8buKXz41kWYMrdRrWqsZaQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.0"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.0"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-label" "1.0.0"
+    "@radix-ui/react-portal" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-use-previous" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.4"
 
 "@radix-ui/react-slot@1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,34 @@
     "@radix-ui/react-use-callback-ref" "1.0.0"
     "@radix-ui/react-use-controllable-state" "1.0.0"
 
+"@radix-ui/react-select@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-1.0.0.tgz#16d91f493a18e471d40fc06b1faff516b5686784"
+  integrity sha512-GfbVBxx7JPvytNT+0XYCFCOImEMmpl0Vg7hhifLaLV7p5zRottFMgQ7qrrxw8v6B8buKXz41kWYMrdRrWqsZaQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.0"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.0"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-label" "1.0.0"
+    "@radix-ui/react-portal" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-use-previous" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.4"
+
 "@radix-ui/react-slot@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.0.tgz#7fa805b99891dea1e862d8f8fbe07f4d6d0fd698"


### PR DESCRIPTION
- close #49 

# 概要
`@radix-ui/react-select`を使用することで、キーボード操作が可能でアクセシビリティの確保されたセレクタを作成した。
セレクタの選択肢内のグルーピングと区分けによる整理が可能。
選択肢の表示に、テキストのみならずアイコン等を使用可能。

# コードの例
```tsx
<Selector
    aria-label="category"
  >
    <SelectorGroup label="日付ごと">
      <SelectorItem value="day1">
        一日目のみ
      </SelectorItem>
      <SelectorItem value="day2">
        二日目のみ
      </SelectorItem>
    </SelectorGroup>
    <SelectorSeparator />
    <SelectorGroup label="使用キャラごと">
      <SelectorItem value="fox">
        <Icon
          alt="きゅうびさんの画像"
          className="h-6"
          src="/icons/fox.png"
        />
        <span className="font-bold">
          きゅうびさん
        </span>
        のみ
      </SelectorItem>
      <SelectorItem value="cat">
        <Icon
          alt="ねこさんの画像"
          className="h-6"
          src="/icons/cat.png"
        />
        <span className="font-bold">
          ねこさん
        </span>
        のみ
      </SelectorItem>
    </SelectorGroup>
  </Selector>
```

# ストーリー
![image](https://user-images.githubusercontent.com/16751535/189246084-043c0d74-9077-4f28-80f2-8d3716b735e0.png)

![image](https://user-images.githubusercontent.com/16751535/189245957-5c201315-ab6e-43e8-b35a-74832535b313.png)
![image](https://user-images.githubusercontent.com/16751535/189245980-37adef20-8676-4025-b6c0-f26ca4a5696a.png)
