### PR TITLE
モーダルの`<ModalOverlay>``<ModalContent>`の露出とボタングループ用の`<ModalButtonGroup>`の追加

### DIFF
--- a/src/components/Modal/Modal.story.tsx
+++ b/src/components/Modal/Modal.story.tsx
@@ -2,7 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { Modal, ModalTitle, ModalDescription } from './index';
+import { Modal, ModalTitle, ModalDescription, ModalOverlay, ModalContent } from './index';
 import { Button } from '@/components/Button';
 
 type Story = ComponentStoryObj<typeof Modal>;
@@ -25,7 +25,8 @@ const meta: ComponentMeta<typeof Modal> = {
       control: { type: 'none' },
     },
     children: {
-      description: 'このモーダルのコンテンツとなる子要素を指定できる。',
+      description:
+        'このモーダルのコンテンツとなる子要素を指定できる。オーバーレイを提供する`<ModalOverlay>`の子要素として`<ModalContent>`を与え、その子要素としてモーダルのコンテンツを与える。',
       defaultValue: '内容がテキストのみのモーダルです。',
       control: { type: 'text' },
     },
@@ -35,13 +36,23 @@ const meta: ComponentMeta<typeof Modal> = {
 export default meta;
 
 export const Default: Story = {
-  render: () => (
-    <Modal trigger={<Button onClick={action('onClick [モーダルを開くボタンが押されました。]')}>モーダルを開く</Button>}>
-      <ModalTitle>本当に良いのですか？</ModalTitle>
-      <ModalDescription>この動作をすると何かが起こります。画面外をクリックすると閉じることができます。</ModalDescription>
-      <Button onClick={action('onClick [モーダルの中の確定ボタンが押されました。]')}>
-        確定<span className="text-neutral-700">押しても閉じないよ</span>
-      </Button>
+  render: (args) => (
+    <Modal
+      trigger={
+        <Button onClick={action('onClick [モーダルを開くボタンが押されました。]')} {...args}>
+          モーダルを開く
+        </Button>
+      }
+    >
+      <ModalOverlay>
+        <ModalContent>
+          <ModalTitle>本当に良いのですか？</ModalTitle>
+          <ModalDescription>この動作をすると何かが起こります。画面外をクリックすると閉じることができます。</ModalDescription>
+          <Button onClick={action('onClick [モーダルの中の確定ボタンが押されました。]')}>
+            確定<span className="text-neutral-700">押しても閉じないよ</span>
+          </Button>
+        </ModalContent>
+      </ModalOverlay>
     </Modal>
   ),
 };
@@ -50,4 +61,26 @@ export const WithPassedOpenProps: Story = {
   args: {
     trigger: <Button>モーダルを開く</Button>,
   },
+};
+
+export const WithCustomStyle: Story = {
+  render: (args) => (
+    <Modal
+      trigger={
+        <Button onClick={action('onClick [モーダルを開くボタンが押されました。]')} {...args}>
+          モーダルを開く
+        </Button>
+      }
+    >
+      <ModalOverlay className="bg-gradient-to-br gradient-primary">
+        <ModalContent className="bg-transparent text-white shadow-none">
+          <ModalTitle>本当に良いのですか？</ModalTitle>
+          <ModalDescription>この動作をすると何かが起こります。画面外をクリックすると閉じることができます。</ModalDescription>
+          <Button onClick={action('onClick [モーダルの中の確定ボタンが押されました。]')}>
+            確定<span className="text-neutral-700">押しても閉じないよ</span>
+          </Button>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  ),
 };

--- a/src/components/Modal/Modal.story.tsx
+++ b/src/components/Modal/Modal.story.tsx
@@ -2,7 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { Modal, ModalTitle, ModalDescription, ModalOverlay, ModalContent } from './index';
+import { Modal, ModalTitle, ModalDescription, ModalOverlay, ModalContent, ModalButtonGroup } from './index';
 import { Button } from '@/components/Button';
 
 type Story = ComponentStoryObj<typeof Modal>;
@@ -57,6 +57,35 @@ export const Default: Story = {
   ),
 };
 
+export const WithButtonGroup: Story = {
+  render: (args) => (
+    <Modal
+      trigger={
+        <Button onClick={action('onClick [モーダルを開くボタンが押されました。]')} {...args}>
+          モーダルを開く
+        </Button>
+      }
+    >
+      <ModalOverlay>
+        <ModalContent>
+          <ModalTitle>本当に良いのですか？</ModalTitle>
+          <ModalDescription>この動作をすると何かが起こります。画面外をクリックすると閉じることができます。</ModalDescription>
+          <ModalButtonGroup>
+            <Button outlined className="border-error-500 text-error-500" onClick={action('onClick [モーダルの中のキャンセルボタンが押されました。]')}>
+              キャンセル
+            </Button>
+            <Button outlined className="border-info-500 text-info-500" onClick={action('onClick [モーダルの中の変更ボタンが押されました。]')}>
+              変更
+            </Button>
+            <Button className="col-span-2" onClick={action('onClick [モーダルの中の確定ボタンが押されました。]')}>
+              確定<span className="text-neutral-700">押しても閉じないよ</span>
+            </Button>
+          </ModalButtonGroup>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  ),
+};
 export const WithPassedOpenProps: Story = {
   args: {
     trigger: <Button>モーダルを開く</Button>,

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -26,6 +26,22 @@ export const ModalDescription: FC<ModalDescriptionProps> = ({ className, childre
   </Dialog.Description>
 );
 
+export type ModalButtonGroupProps = ComponentPropsWithoutRef<'div'> & {
+  children: Array<ComponentPropsWithoutRef<'button'> | ReactElement<ButtonProps>> | ComponentPropsWithoutRef<'button'> | ReactElement<ButtonProps>;
+};
+
+export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({ className, children, ...props }) => (
+  <div
+    className={twMerge(
+      'overflow-visible rounded-base bg-neutral-100 w-full m-0 p-2 grid grid-cols-2 auto-row-fr grid-flow-row-dense gap-2',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
 export type ModalContentProps = MotionCardProps;
 
 export const ModalContent: FC<ModalContentProps> = ({ className, children, ...props }) => (

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,20 +4,6 @@ import type { ButtonProps } from '@/components/Button';
 import { MotionCard, MotionCardProps } from '@/components/Card';
 import twMerge from '@/libs/twmerge';
 
-type ModalContentProps = MotionCardProps;
-
-const ModalContent: FC<ModalContentProps> = ({ className, children, ...props }) => (
-  <MotionCard
-    initial={{ opacity: 0, scale: 1.2 }}
-    animate={{ opacity: 1, scale: 1.0 }}
-    exit={{ opacity: 0, scale: 0.8 }}
-    className={twMerge('relative p-6 gap-4 max-w-lg shadow-z32', className)}
-    {...props}
-  >
-    {children}
-  </MotionCard>
-);
-
 export type ModalTitleProps = ComponentPropsWithoutRef<typeof Dialog.Title> & {
   children: ReactNode;
 };
@@ -40,21 +26,42 @@ export const ModalDescription: FC<ModalDescriptionProps> = ({ className, childre
   </Dialog.Description>
 );
 
+export type ModalContentProps = MotionCardProps;
+
+export const ModalContent: FC<ModalContentProps> = ({ className, children, ...props }) => (
+  <MotionCard
+    initial={{ opacity: 0, scale: 1.2 }}
+    animate={{ opacity: 1, scale: 1.0 }}
+    exit={{ opacity: 0, scale: 0.8 }}
+    className={twMerge('relative p-6 gap-4 max-w-lg shadow-z32', className)}
+    {...props}
+  >
+    {children}
+  </MotionCard>
+);
+
+export type ModalOverlayProps = ComponentPropsWithoutRef<typeof Dialog.Overlay> & {
+  children: ReactElement<ModalContentProps>;
+};
+
+export const ModalOverlay: FC<ModalOverlayProps> = ({ className, children, ...props }) => (
+  <Dialog.Overlay
+    className={twMerge('fixed inset-0 z-50 flex min-h-screen w-screen items-center justify-center bg-neutral-900/50', className)}
+    {...props}
+  >
+    <Dialog.Content asChild>{children}</Dialog.Content>
+  </Dialog.Overlay>
+);
+
 export type ModalProps = Pick<ComponentPropsWithoutRef<typeof Dialog.Root>, 'open' | 'onOpenChange'> & {
   trigger: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
-  children: ReactNode;
+  children: ReactElement<ModalOverlayProps>;
 };
 
 // モーダルのトリガーとなるボタンとモーダルの中身を受け取り、モーダルを表示する本体となるコンポーネント
 export const Modal: FC<ModalProps> = ({ open, onOpenChange, trigger, children }) => (
   <Dialog.Root open={open} onOpenChange={onOpenChange}>
     <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
-    <Dialog.Portal>
-      <Dialog.Overlay className="fixed inset-0 z-50 flex min-h-screen w-screen items-center justify-center bg-neutral-900/50">
-        <Dialog.Content asChild>
-          <ModalContent>{children}</ModalContent>
-        </Dialog.Content>
-      </Dialog.Overlay>
-    </Dialog.Portal>
+    <Dialog.Portal>{children}</Dialog.Portal>
   </Dialog.Root>
 );


### PR DESCRIPTION
- close #44 
- close #53 

#44と#53でブランチとPRを分けてやると、あとあとコンフリクトの解消が面倒そうだったのでまとめました。
# 概要
## `<ModalOverlay>``<ModalContent>`の露出
HamburgerMenu #2 で`<Modal>`を再利用するために必須だったので、オーバレイとコンテンツのスタイルを露出させました。それに伴い`<Modal>`に与える子要素の構造も変更が加わっています。
**現在、`shadow-z16`等のシャドークラスの上書きができない #54 ので、はやめに直します。**
```tsx
<Modal
      trigger={
        <Button onClick={action('onClick [モーダルを開くボタンが押されました。]')} {...args}>
          モーダルを開く
        </Button>
      }
    >
      <ModalOverlay className="bg-gradient-to-br gradient-primary"> {/* ←これを追加 */}
        <ModalContent className="bg-transparent text-white shadow-none"> {/* ←これを追加 */}
          <ModalTitle>本当に良いのですか？</ModalTitle>
          <ModalDescription>この動作をすると何かが起こります。画面外をクリックすると閉じることができます。</ModalDescription>
          <Button onClick={action('onClick [モーダルの中の確定ボタンが押されました。]')}>
            確定<span className="text-neutral-700">押しても閉じないよ</span>
          </Button>
        </ModalContent>
      </ModalOverlay>
    </Modal>
```
![image](https://user-images.githubusercontent.com/16751535/189267609-8ea0acb9-6405-49f8-bcd6-0f713655201e.png)
## `<ModalButtonGroup>`の追加
モーダル内に複数のボタンを配置する際の実装にばらつきが生まれそう+車輪の再発明がたくさんおこりそうだったので、モーダル用のボタングループコンポーネントを作成しました。
![image](https://user-images.githubusercontent.com/16751535/189268486-c34f1222-b0ad-4b82-b61c-040618bafa85.png)
