### PR TITLE
TailwindCSSの独自クラスの`shadow-z*` `rounded-base` `gradient-*` の対立が解決できない問題を解決した。

### DIFF
--- a/src/libs/twmerge/index.ts
+++ b/src/libs/twmerge/index.ts
@@ -1,12 +1,17 @@
 import { extendTailwindMerge } from 'tailwind-merge';
 
-const isGradientName = (classPart: string) => /^\.+\$/.test(classPart);
+// 英数字のみの文字列ならtrueを返す
+export const isGradientName = (classPart: string) => /\w+/.test(classPart);
 
 // .tailwind.config.jsで指定した独自のグラデーション用のユーティリティクラス .gradient-* を解決できるように設定する
 // 参照: https://github.com/dcastil/tailwind-merge/blob/v1.6.0/docs/configuring-tailwind-merge.md
 const twMerge = extendTailwindMerge({
+  theme: {
+    borderRadius: ['base'],
+  },
   classGroups: {
-    gradient: [isGradientName],
+    gradient: [{ gradient: [isGradientName] }],
+    shadow: [{ shadow: ['z4', 'z8', 'z16', 'z24', 'z32'] }],
   },
 });
 

--- a/src/libs/twmerge/twmerge.spec.ts
+++ b/src/libs/twmerge/twmerge.spec.ts
@@ -1,17 +1,17 @@
 import twMerge, { isGradientName } from '.';
 
 describe('twMerge', () => {
-  it('独自クラス"shadow-z*"の対立を解決できる', () => {
+  test('独自クラス"shadow-z*"の対立を解決できる', () => {
     expect(twMerge('shadow-z4 shadow-z8')).toBe('shadow-z8');
     expect(twMerge('shadow-xl shadow-z8')).toBe('shadow-z8');
   });
-  it('独自クラス"gradient-*"の対立を解決できる', () => {
+  test('独自クラス"gradient-*"の対立を解決できる', () => {
     expect(twMerge('gradient-primary gradient-game')).toBe('gradient-game');
   });
-  it('独自クラス"rounded-base"の対立を解決できる', () => {
+  test('独自クラス"rounded-base"の対立を解決できる', () => {
     expect(twMerge('rounded-base rounded-3xl')).toBe('rounded-3xl');
   });
-  it('isGradientName()がグラデーション名を識別できる', () => {
+  test('isGradientName()がグラデーション名を識別できる', () => {
     expect(isGradientName('primary')).toBe(true);
   });
 });

--- a/src/libs/twmerge/twmerge.spec.ts
+++ b/src/libs/twmerge/twmerge.spec.ts
@@ -1,0 +1,17 @@
+import twMerge, { isGradientName } from '.';
+
+describe('twMerge', () => {
+  it('独自クラス"shadow-z*"の対立を解決できる', () => {
+    expect(twMerge('shadow-z4 shadow-z8')).toBe('shadow-z8');
+    expect(twMerge('shadow-xl shadow-z8')).toBe('shadow-z8');
+  });
+  it('独自クラス"gradient-*"の対立を解決できる', () => {
+    expect(twMerge('gradient-primary gradient-game')).toBe('gradient-game');
+  });
+  it('独自クラス"rounded-base"の対立を解決できる', () => {
+    expect(twMerge('rounded-base rounded-3xl')).toBe('rounded-3xl');
+  });
+  it('isGradientName()がグラデーション名を識別できる', () => {
+    expect(isGradientName('primary')).toBe(true);
+  });
+});


### PR DESCRIPTION
- close #54 