### PR TITLE
ラジオボタン用のコンポーネント`<RadioGroup>` `<RadioItem>` `<RadioIndicator>`を作成した。

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.0",
+    "@radix-ui/react-label": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.0.0",
     "@radix-ui/react-radio-group": "^1.0.0",
     "@urql/devtools": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.0.0",
+    "@radix-ui/react-radio-group": "^1.0.0",
     "@urql/devtools": "^2.0.3",
     "@urql/exchange-auth": "^1.0.0",
     "daisyui": "^2.24.0",

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -7,7 +7,7 @@ export type LabelProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveLabel.Roo
 };
 
 export const Label: FC<LabelProps> = ({ className, children, ...props }) => (
-  <PrimitiveLabel.Root className={twMerge('text-neutral-700 font-branding font-bold focus:text-neutral-900', className)} {...props}>
+  <PrimitiveLabel.Root className={twMerge("text-neutral-900 font-branding [&[data-state='checked']]:font-bold", className)} {...props}>
     {children}
   </PrimitiveLabel.Root>
 );

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,5 +1,5 @@
 import * as PrimitiveLabel from '@radix-ui/react-label';
-import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import type { FC, ComponentPropsWithoutRef, ReactNode } from 'react';
 import twMerge from '@/libs/twmerge';
 
 export type LabelProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveLabel.Root>, 'asChild'> & {

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,13 @@
+import * as PrimitiveLabel from '@radix-ui/react-label';
+import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import twMerge from '@/libs/twmerge';
+
+export type LabelProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveLabel.Root>, 'asChild'> & {
+  children: ReactNode;
+};
+
+export const Label: FC<LabelProps> = ({ className, children, ...props }) => (
+  <PrimitiveLabel.Root className={twMerge('text-neutral-700 font-branding font-bold focus:text-neutral-900', className)} {...props}>
+    {children}
+  </PrimitiveLabel.Root>
+);

--- a/src/components/Radio/Radio.story.tsx
+++ b/src/components/Radio/Radio.story.tsx
@@ -40,17 +40,17 @@ export const Default: Story = {
   render: (args) => (
     <form>
       <RadioGroup {...args}>
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row justify-start gap-2">
           <RadioItem value="apple" id="radio-option-1" />
           <Label htmlFor="radio-option-1">林檎</Label>
         </div>
 
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row justify-start gap-2">
           <RadioItem value="grape" id="radio-option-2" />
           <Label htmlFor="radio-option-2">葡萄</Label>
         </div>
 
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row justify-start gap-2">
           <RadioItem value="iyokan" id="radio-option-3" />
           <Label htmlFor="radio-option-3">伊予柑</Label>
         </div>
@@ -63,9 +63,17 @@ export const LargeButton: Story = {
   render: (args) => (
     <form>
       <RadioGroup {...args}>
-        <RadioItem className="flex aspect-auto h-fit flex-col rounded-base p-4" value="fox" id="radio-option-1">
-          <Icon className="h-36" src="/icons/fox.png" alt="アイコン画像の例" />
-          <Label htmlFor="radio-option-1">きゅうびさん</Label>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3" value="fox" id="radio-option-1">
+          <Icon className="h-8" src="/icons/fox.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-1">
+            きゅうびさん
+          </Label>
+        </RadioItem>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 " value="cat" id="radio-option-2">
+          <Icon className="h-8" src="/icons/cat.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-2">
+            ねこさん
+          </Label>
         </RadioItem>
       </RadioGroup>
     </form>

--- a/src/components/Radio/Radio.story.tsx
+++ b/src/components/Radio/Radio.story.tsx
@@ -1,0 +1,73 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { RadioGroup, RadioItem, RadioIndicator, RadioButton } from '.';
+import { Button } from '@/components/Button';
+import { Icon } from '@/components/Icon';
+import { Label } from '@/components/Label';
+
+type Story = ComponentStoryObj<typeof RadioGroup>;
+
+const meta: ComponentMeta<typeof RadioGroup> = {
+  component: RadioGroup,
+  args: {
+    onValueChange: action('onValueChange'),
+  },
+  argTypes: {
+    defaultValue: {
+      description: 'このラジオボタングループの初期状態の選択肢`<RadioItem>`の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    value: {
+      description: 'このラジオボタングループで現在選択されている選択肢`<RadioItem>`の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    onValueChange: {
+      description: 'このラジオボタングループで選択される選択肢が変更されるときに、その`value`とともに呼び出されるイベントハンドラを指定できる。',
+      control: { type: 'none' },
+    },
+    children: {
+      description: 'このラジオボタングループが持つ選択肢となる子要素を`<RadioItem>`を与えることにより指定できる。',
+      control: { type: 'none' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  render: (args) => (
+    <form>
+      <RadioGroup {...args}>
+        <div className="flex flex-row gap-2">
+          <RadioItem value="apple" id="radio-option-1" />
+          <Label htmlFor="radio-option-1">林檎</Label>
+        </div>
+
+        <div className="flex flex-row gap-2">
+          <RadioItem value="grape" id="radio-option-2" />
+          <Label htmlFor="radio-option-2">葡萄</Label>
+        </div>
+
+        <div className="flex flex-row gap-2">
+          <RadioItem value="iyokan" id="radio-option-3" />
+          <Label htmlFor="radio-option-3">伊予柑</Label>
+        </div>
+      </RadioGroup>
+    </form>
+  ),
+};
+
+export const LargeButton: Story = {
+  render: (args) => (
+    <form>
+      <RadioGroup {...args}>
+        <RadioItem className="flex aspect-auto h-fit flex-col rounded-base p-4" value="fox" id="radio-option-1">
+          <Icon className="h-36" src="/icons/fox.png" alt="アイコン画像の例" />
+          <Label htmlFor="radio-option-1">きゅうびさん</Label>
+        </RadioItem>
+      </RadioGroup>
+    </form>
+  ),
+};

--- a/src/components/Radio/Radio.story.tsx
+++ b/src/components/Radio/Radio.story.tsx
@@ -2,7 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { RadioGroup, RadioItem, RadioIndicator, RadioButton } from '.';
+import { RadioGroup, RadioItem, RadioIndicator } from '.';
 import { Button } from '@/components/Button';
 import { Icon } from '@/components/Icon';
 import { Label } from '@/components/Label';
@@ -13,6 +13,7 @@ const meta: ComponentMeta<typeof RadioGroup> = {
   component: RadioGroup,
   args: {
     onValueChange: action('onValueChange'),
+    orientation: 'vertical',
   },
   argTypes: {
     defaultValue: {
@@ -31,12 +32,37 @@ const meta: ComponentMeta<typeof RadioGroup> = {
       description: 'このラジオボタングループが持つ選択肢となる子要素を`<RadioItem>`を与えることにより指定できる。',
       control: { type: 'none' },
     },
+    name: {
+      description: '`<form>`で送信するときに選択されている`value`に紐づけて使われる名前を指定できる。',
+      control: { type: 'boolean' },
+    },
+    required: {
+      description: 'このラジオボタングループが`<form>`を送信するのに必須であるかどうかを指定できる。',
+      control: { type: 'boolean' },
+    },
+    loop: {
+      description: 'キーボード操作のときに、始点と末端をつなげるかどうかを指定できる。',
+      control: { type: 'boolean' },
+      defaultValue: true,
+    },
+    orientation: {
+      description:
+        'このラジオボタングループの選択肢が横に並んでいるか縦に並んでいるか未規定(`undefined`)かを指定できる。キーボード操作のときに使われるキーにのみ影響する。見た目には影響しない。',
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical', undefined],
+      defaultValue: undefined,
+    },
   },
 };
 
 export default meta;
 
 export const Default: Story = {
+  args: {
+    name: 'fruit',
+    defaultValue: 'apple',
+    required: true,
+  },
   render: (args) => (
     <form>
       <RadioGroup {...args}>
@@ -51,7 +77,7 @@ export const Default: Story = {
         </div>
 
         <div className="flex flex-row justify-start gap-2">
-          <RadioItem value="iyokan" id="radio-option-3" />
+          <RadioItem disabled value="iyokan" id="radio-option-3" />
           <Label htmlFor="radio-option-3">伊予柑</Label>
         </div>
       </RadioGroup>
@@ -59,7 +85,7 @@ export const Default: Story = {
   ),
 };
 
-export const LargeButton: Story = {
+export const WithCustomStyle: Story = {
   render: (args) => (
     <form>
       <RadioGroup {...args}>
@@ -73,6 +99,35 @@ export const LargeButton: Story = {
           <Icon className="h-8" src="/icons/cat.png" alt="アイコン画像の例" />
           <Label className="" htmlFor="radio-option-2">
             ねこさん
+          </Label>
+        </RadioItem>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 " value="tree" id="radio-option-3">
+          <Icon className="h-8" src="/icons/tree.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-3">
+            おおもりさん
+          </Label>
+        </RadioItem>
+        <RadioItem
+          disabled
+          className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 "
+          value="goku"
+          id="radio-option-4"
+        >
+          <Icon className="h-8" src="/icons/goku.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-4">
+            そんごくう
+          </Label>
+        </RadioItem>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 " value="reaper" id="radio-option-5">
+          <Icon className="h-8" src="/icons/reaper.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-5">
+            りっぱーさん
+          </Label>
+        </RadioItem>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 " value="pudding" id="radio-option-6">
+          <Icon className="h-8" src="/icons/pudding.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-6">
+            ぷりん
           </Label>
         </RadioItem>
       </RadioGroup>

--- a/src/components/Radio/Radio.story.tsx
+++ b/src/components/Radio/Radio.story.tsx
@@ -2,8 +2,7 @@
 import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
-import { RadioGroup, RadioItem, RadioIndicator } from '.';
-import { Button } from '@/components/Button';
+import { RadioGroup, RadioItem } from '.';
 import { Icon } from '@/components/Icon';
 import { Label } from '@/components/Label';
 

--- a/src/components/Radio/RadioItem.story.tsx
+++ b/src/components/Radio/RadioItem.story.tsx
@@ -1,0 +1,88 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from '@storybook/addon-actions';
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { RadioGroup, RadioItem } from '.';
+import { Icon } from '@/components/Icon';
+import { Label } from '@/components/Label';
+
+type Story = ComponentStoryObj<typeof RadioItem>;
+
+const meta: ComponentMeta<typeof RadioItem> = {
+  component: RadioItem,
+  args: {
+    required: false,
+    disabled: false,
+  },
+  argTypes: {
+    value: {
+      description: 'このラジオボタンが選ばれたときに親の`<RadioGroup>`で使われる値の`value`を指定できる。',
+      control: { type: 'text' },
+    },
+    required: {
+      description: 'このラジオボタンが選ばれていることが`<form>`を送信するのに必須であるかどうかを指定できる。',
+      control: { type: 'boolean' },
+    },
+    disabled: {
+      description: 'このラジオボタンが選択可能かどうかを指定できる。',
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
+    id: {
+      description: 'HTML準拠。ラベル付のために使用してください。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    value: 'apple',
+  },
+  render: (args) => (
+    <form>
+      <RadioGroup>
+        <div className="flex flex-row justify-start gap-2">
+          <RadioItem id="radio-option-1" {...args} />
+          <Label htmlFor="radio-option-1">林檎</Label>
+        </div>
+
+        <div className="flex flex-row justify-start gap-2">
+          <RadioItem value="grape" id="radio-option-2" />
+          <Label htmlFor="radio-option-2">葡萄</Label>
+        </div>
+
+        <div className="flex flex-row justify-start gap-2">
+          <RadioItem value="iyokan" id="radio-option-3" />
+          <Label htmlFor="radio-option-3">伊予柑</Label>
+        </div>
+      </RadioGroup>
+    </form>
+  ),
+};
+
+export const WithCustomStyle: Story = {
+  args: {
+    value: 'fox',
+  },
+  render: (args) => (
+    <form>
+      <RadioGroup onValueChange={action('onValueChange')}>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3" id="radio-option-1" {...args}>
+          <Icon className="h-8" src="/icons/fox.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-1">
+            きゅうびさん
+          </Label>
+        </RadioItem>
+        <RadioItem className="flex aspect-auto h-fit w-full flex-row justify-start gap-2 rounded-base p-2 pr-3 " value="cat" id="radio-option-2">
+          <Icon className="h-8" src="/icons/cat.png" alt="アイコン画像の例" />
+          <Label className="" htmlFor="radio-option-2">
+            ねこさん
+          </Label>
+        </RadioItem>
+      </RadioGroup>
+    </form>
+  ),
+};

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,0 +1,43 @@
+import * as PrimitiveRadioGroup from '@radix-ui/react-radio-group';
+import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
+import twMerge from '@/libs/twmerge';
+
+export type RadioIndicatorProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Indicator>, 'asChild' | 'children'> & {
+  children: ReactNode;
+};
+
+export const RadioIndicator: FC<RadioIndicatorProps> = ({ children, ...props }) => (
+  <PrimitiveRadioGroup.Indicator asChild {...props}>
+    {children}
+  </PrimitiveRadioGroup.Indicator>
+);
+
+export type DefaultRadioButtonAppearanceProps = ComponentPropsWithoutRef<'div'>;
+
+export const DefaultRadioButtonAppearance: FC<DefaultRadioButtonAppearanceProps> = (props) => (
+  <div className="m-0 flex aspect-square h-6 items-center justify-center rounded-full bg-neutral-100 p-2 shadow-z16" {...props}>
+    <RadioIndicator>
+      <div className="aspect-square h-full rounded-full bg-success-700" />
+    </RadioIndicator>
+  </div>
+);
+
+export type RadioItemProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Item>, 'asChild' | 'children'> & {
+  children?: ReactNode;
+};
+
+export const RadioItem: FC<RadioItemProps> = ({ className, children, ...props }) => (
+  <PrimitiveRadioGroup.Item asChild {...props}>
+    {children}
+  </PrimitiveRadioGroup.Item>
+);
+
+RadioItem.defaultProps = {
+  children: <DefaultRadioButtonAppearance />,
+};
+
+export type RadioGroupProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Root>, 'asChild' | 'children'> & {
+  children: Array<ReactElement<RadioItemProps>> | ReactElement<RadioItemProps>;
+};
+
+export const RadioGroup: FC<RadioGroupProps> = ({ children, ...props }) => <PrimitiveRadioGroup.Root {...props}>{children}</PrimitiveRadioGroup.Root>;

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,43 +1,52 @@
 import * as PrimitiveRadioGroup from '@radix-ui/react-radio-group';
+import { motion } from 'framer-motion';
 import type { FC, ComponentPropsWithoutRef, ReactNode, ReactElement } from 'react';
 import twMerge from '@/libs/twmerge';
 
-export type RadioIndicatorProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Indicator>, 'asChild' | 'children'> & {
-  children: ReactNode;
-};
+export type RadioIndicatorProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Indicator>, 'asChild'>;
 
-export const RadioIndicator: FC<RadioIndicatorProps> = ({ children, ...props }) => (
-  <PrimitiveRadioGroup.Indicator asChild {...props}>
+export const RadioIndicator: FC<RadioIndicatorProps> = ({ className, children, ...props }) => (
+  <PrimitiveRadioGroup.Indicator
+    className={twMerge('aspect-square h-full rounded-full bg-gradient-to-br shadow-z4 gradient-primary', className)}
+    {...props}
+  >
     {children}
   </PrimitiveRadioGroup.Indicator>
 );
 
-export type DefaultRadioButtonAppearanceProps = ComponentPropsWithoutRef<'div'>;
+const MotionPrimitiveRadioGroupItem = motion(PrimitiveRadioGroup.Item);
 
-export const DefaultRadioButtonAppearance: FC<DefaultRadioButtonAppearanceProps> = (props) => (
-  <div className="m-0 flex aspect-square h-6 items-center justify-center rounded-full bg-neutral-100 p-2 shadow-z16" {...props}>
-    <RadioIndicator>
-      <div className="aspect-square h-full rounded-full bg-success-700" />
-    </RadioIndicator>
-  </div>
-);
-
-export type RadioItemProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Item>, 'asChild' | 'children'> & {
+export type RadioItemProps = Omit<ComponentPropsWithoutRef<typeof MotionPrimitiveRadioGroupItem>, 'asChild'> & {
   children?: ReactNode;
 };
 
 export const RadioItem: FC<RadioItemProps> = ({ className, children, ...props }) => (
-  <PrimitiveRadioGroup.Item asChild {...props}>
+  <MotionPrimitiveRadioGroupItem
+    whileHover={{
+      scale: 1.05,
+      transition: { duration: 0.25 },
+    }}
+    whileTap={{ scale: 0.95 }}
+    className={twMerge(
+      "m-0 flex aspect-square h-6 items-center justify-center rounded-full bg-white p-1.5 shadow-z16 ring-primary [&[data-state='checked']]:ring-2",
+      className,
+    )}
+    {...props}
+  >
     {children}
-  </PrimitiveRadioGroup.Item>
+  </MotionPrimitiveRadioGroupItem>
 );
 
 RadioItem.defaultProps = {
-  children: <DefaultRadioButtonAppearance />,
+  children: <RadioIndicator />,
 };
 
 export type RadioGroupProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadioGroup.Root>, 'asChild' | 'children'> & {
   children: Array<ReactElement<RadioItemProps>> | ReactElement<RadioItemProps>;
 };
 
-export const RadioGroup: FC<RadioGroupProps> = ({ children, ...props }) => <PrimitiveRadioGroup.Root {...props}>{children}</PrimitiveRadioGroup.Root>;
+export const RadioGroup: FC<RadioGroupProps> = ({ className, children, ...props }) => (
+  <PrimitiveRadioGroup.Root className={twMerge('flex flex-col items-center gap-4 w-fit', className)} {...props}>
+    {children}
+  </PrimitiveRadioGroup.Root>
+);

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -46,7 +46,7 @@ export type RadioGroupProps = Omit<ComponentPropsWithoutRef<typeof PrimitiveRadi
 };
 
 export const RadioGroup: FC<RadioGroupProps> = ({ className, children, ...props }) => (
-  <PrimitiveRadioGroup.Root className={twMerge('flex flex-col items-center gap-4 w-fit', className)} {...props}>
+  <PrimitiveRadioGroup.Root className={twMerge('flex flex-col items-start gap-4 w-fit', className)} {...props}>
     {children}
   </PrimitiveRadioGroup.Root>
 );

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -23,12 +23,12 @@ export type RadioItemProps = Omit<ComponentPropsWithoutRef<typeof MotionPrimitiv
 export const RadioItem: FC<RadioItemProps> = ({ className, children, ...props }) => (
   <MotionPrimitiveRadioGroupItem
     whileHover={{
-      scale: 1.05,
+      scale: props.disabled ? 1.0 : 1.05,
       transition: { duration: 0.25 },
     }}
-    whileTap={{ scale: 0.95 }}
+    whileTap={{ scale: props.disabled ? 1.0 : 0.95 }}
     className={twMerge(
-      "m-0 flex aspect-square h-6 items-center justify-center rounded-full bg-white p-1.5 shadow-z16 ring-primary [&[data-state='checked']]:ring-2",
+      "m-0 flex aspect-square h-6 items-center justify-center rounded-full bg-white p-1.5 disabled:contrast-50 shadow-z16 ring-2 ring-transparent [&[data-state='checked']]:ring-primary",
       className,
     )}
     {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,6 +2892,17 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
+"@radix-ui/react-label@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-1.0.0.tgz#c6691b0bec18958512a952c18732279285b61fef"
+  integrity sha512-k+EbxeRaVbSJ4oaR9eUYuC0cDIGRB4TAPhilbFCIMpP9pXFNcyQPQUvRaVOQBrviuArYM80xh0BQR/0y3kjUdQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+
 "@radix-ui/react-navigation-menu@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.0.0.tgz#5aaf65967794147eee52e87930191c55d08bd213"
@@ -2938,6 +2949,40 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.0"
 
+"@radix-ui/react-radio-group@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.0.0.tgz#16267bdfc3c1bd293a6ac1b34f3e9b484e88ebf8"
+  integrity sha512-WekhUjLzH6/ZXQNAum2NNww+0zvOIfFu96+AZ1XXxWolq82vNAgqMbPrxyqij2H/sa33wbjqspErybsTLtVTDA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-label" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-roving-focus" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-use-previous" "1.0.0"
+    "@radix-ui/react-use-size" "1.0.0"
+
+"@radix-ui/react-roving-focus@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.0.tgz#aadeb65d5dbcdbdd037078156ae1f57c2ff754ee"
+  integrity sha512-lHvO4MhvoWpeNbiJAoyDsEtbKqP2jkkdwsMVJ3kfqbkC71J/aXE6Th6gkZA1xHEqSku+t+UgoDjvE7Z3gsBpcg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+
 "@radix-ui/react-slot@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.0.tgz#7fa805b99891dea1e862d8f8fbe07f4d6d0fd698"
@@ -2982,6 +3027,14 @@
   integrity sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-size@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz#a0b455ac826749419f6354dc733e2ca465054771"
+  integrity sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
 
 "@radix-ui/react-visually-hidden@1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,7 +2892,7 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
-"@radix-ui/react-label@1.0.0":
+"@radix-ui/react-label@1.0.0", "@radix-ui/react-label@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-1.0.0.tgz#c6691b0bec18958512a952c18732279285b61fef"
   integrity sha512-k+EbxeRaVbSJ4oaR9eUYuC0cDIGRB4TAPhilbFCIMpP9pXFNcyQPQUvRaVOQBrviuArYM80xh0BQR/0y3kjUdQ==


### PR DESCRIPTION
- close #57

# 概要
キーボード操作などのアクセシビリティとスタイルの自由度が確保されたラジオボタンのためのコンポーネント群です。

# コードの例
```tsx
<form>
  <RadioGroup
    defaultValue="apple"
    loop
    name="fruit"
    onValueChange={() => {}}
    required
  >
    <div className="flex flex-row justify-start gap-2">
      <RadioItem
        id="radio-option-1"
        value="apple"
      >
        <RadioIndicator />
      </RadioItem>
      <Label htmlFor="radio-option-1">
        林檎
      </Label>
    </div>
    <div className="flex flex-row justify-start gap-2">
      <RadioItem
        id="radio-option-2"
        value="grape"
      >
        <RadioIndicator />
      </RadioItem>
      <Label htmlFor="radio-option-2">
        葡萄
      </Label>
    </div>
    <div className="flex flex-row justify-start gap-2">
      <RadioItem
        disabled
        id="radio-option-3"
        value="iyokan"
      >
        <RadioIndicator />
      </RadioItem>
      <Label htmlFor="radio-option-3">
        伊予柑
      </Label>
    </div>
  </RadioGroup>
</form>
```

# ストーリーから抜粋
![image](https://user-images.githubusercontent.com/16751535/189453309-2f4027ba-800b-4f35-a6b7-b8865eb9f71d.png)
![image](https://user-images.githubusercontent.com/16751535/189453315-884d8d60-d7f0-4294-b751-c059b9744fd9.png)
![image](https://user-images.githubusercontent.com/16751535/189453346-5ab4b4f2-52f0-4b08-a481-8d9570fd6202.png)
![image](https://user-images.githubusercontent.com/16751535/189453944-a57d838b-cb9b-471b-9edc-883b5c9eb92e.png)
