### PR TITLE
アイコンを付随させて使いやすい、スタイル付きのnext/linkのラッパーである<Link>を作成した。

### DIFF
--- a/src/components/Link/Link.story.tsx
+++ b/src/components/Link/Link.story.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { HiUserCircle } from 'react-icons/hi';
+import { Link, LinkIcon } from './index';
+
+type Story = ComponentStoryObj<typeof Link>;
+
+const meta: ComponentMeta<typeof Link> = {
+  component: Link,
+  argTypes: {
+    href: {
+      description:
+        '`next/link`の`<Link>`準拠。リンク先のURL。必須。**このコンポーネントはただのスタイル付きのラッパーなので、この他にも`next/link`の`<Link>`と同じpropsがすべて使用可能。**',
+      control: { type: 'text' },
+    },
+    children: {
+      description:
+        'リンクとして表示されるテキスト。このテキストにアイコンを付随させるために`<LinkIcon>`を子要素として与えられる。**`<LinkIcon>`には`react-icon`のアイコンコンポーネントを唯一の子要素として与えてください。**',
+      control: { type: 'text' },
+    },
+    className: {
+      description:
+        '文字色や大きさなどを変更するために用意されている。アイコン`<LinkIcon>`の大きさはテキストの大きさに合わせて変化するので、アイコンの大きさも変えたい場合でも`text-sm`などテキストの大きさのみの指定で可。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    href: '/',
+    children: 'ここをクリックしてリンク先を訪れる',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    href: '/',
+    className: 'text-info-700',
+  },
+  render: (args) => (
+    <Link {...args}>
+      <LinkIcon>
+        <HiUserCircle />
+      </LinkIcon>
+      あなたのプロフィール
+    </Link>
+  ),
+};
+
+export const WithLargeText: Story = {
+  args: {
+    href: '/',
+    className: 'text-4xl',
+  },
+  render: (args) => (
+    <Link {...args}>
+      <LinkIcon>
+        <HiUserCircle />
+      </LinkIcon>
+      あなたのプロフィール
+    </Link>
+  ),
+};

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,0 +1,32 @@
+import NextLink from 'next/link';
+import type { FC, ReactNode, ReactElement, ComponentPropsWithoutRef } from 'react';
+import { useMemo } from 'react';
+import { IconContext } from 'react-icons';
+import twMerge from '@/libs/twmerge';
+
+export type LinkIconProps = { children: ReactNode };
+
+export const LinkIcon: FC<LinkIconProps> = ({ children }) => {
+  // 親の`<Link>`内のテキストの行の高さに合わせる。
+  const iconContextValue = useMemo(() => ({ size: '1.5em' }), []);
+  //
+  // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-constructed-context-values.md
+  // 再描画の抑制のためにuseMemo()を使う
+  // react-iconsのサイズを変更するために提供されているIconContext.Providerを使う
+  //
+  return (
+    <div className="inline aspect-square max-h-[1.5em] overflow-hidden fill-current">
+      <IconContext.Provider value={iconContextValue}>{children}</IconContext.Provider>
+    </div>
+  );
+};
+
+export type LinkProps = Omit<ComponentPropsWithoutRef<typeof NextLink>, 'children'> & {
+  children: Array<ReactElement<LinkIconProps> | string> | string;
+};
+
+export const Link: FC<LinkProps> = ({ className, children, ...props }) => (
+  <NextLink {...props}>
+    <a className={twMerge('inline-flex items-center gap-1 font-branding font-bold drop-shadow hover:underline', className)}>{children}</a>
+  </NextLink>
+);


### PR DESCRIPTION
- close #59 

# 概要
ただの`next/link`のラッパーです。ですが、与えられる子要素は`<LinkIcon>`とテキストのみに制限しています。
```tsx
<Link href='/user' className='text-lg text-info-700'>
      <LinkIcon>
        <HiUserCircle />
      </LinkIcon>
      あなたのプロフィール
    </Link>
```
このように`react-icon`のコンポーネントを与えるだけで、自動的にアイコンの大きさの調整と色の適用をしてくれます。
# ストーリー
![image](https://user-images.githubusercontent.com/16751535/189466286-2534f9db-8c1f-4a5b-92fd-861163fa13f9.png)
![image](https://user-images.githubusercontent.com/16751535/189466303-b492d003-c218-4fa6-bafe-d9405de9909d.png)
