### PR TITLE
`<HamburgerMenu>`を追加した。また、`<ModalOverlay>`がモーダルの吹き出しのほかに子要素を持てるように変更した。

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,7 @@ import * as NextImage from 'next/image';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import 'tailwindcss/tailwind.css';
 import '../src/styles/global.scss';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 const OriginalNextImage = NextImage.default;
 
@@ -21,5 +22,17 @@ export const parameters = {
   },
   nextRouter: {
     Provider: RouterContext.Provider,
+  },
+  viewport: {
+    viewports: {
+      ...INITIAL_VIEWPORTS,
+      iphone: {
+        name: 'iPhone 13',
+        styles: {
+          width: '390px',
+          height: '844px',
+        },
+      },
+    },
   },
 };

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -45,19 +45,21 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({ className, childre
 export type ModalContentProps = MotionCardProps;
 
 export const ModalContent: FC<ModalContentProps> = ({ className, children, ...props }) => (
-  <MotionCard
-    initial={{ opacity: 0, scale: 1.2 }}
-    animate={{ opacity: 1, scale: 1.0 }}
-    exit={{ opacity: 0, scale: 0.8 }}
-    className={twMerge('relative p-6 gap-4 max-w-lg shadow-z32', className)}
-    {...props}
-  >
-    {children}
-  </MotionCard>
+  <Dialog.Content asChild>
+    <MotionCard
+      initial={{ opacity: 0, scale: 1.2 }}
+      animate={{ opacity: 1, scale: 1.0 }}
+      exit={{ opacity: 0, scale: 0.8 }}
+      className={twMerge('relative p-6 gap-4 max-w-lg shadow-z32', className)}
+      {...props}
+    >
+      {children}
+    </MotionCard>
+  </Dialog.Content>
 );
 
 export type ModalOverlayProps = ComponentPropsWithoutRef<typeof Dialog.Overlay> & {
-  children: ReactElement<ModalContentProps>;
+  children: ReactNode;
 };
 
 export const ModalOverlay: FC<ModalOverlayProps> = ({ className, children, ...props }) => (
@@ -65,7 +67,7 @@ export const ModalOverlay: FC<ModalOverlayProps> = ({ className, children, ...pr
     className={twMerge('fixed inset-0 z-50 flex min-h-screen w-screen items-center justify-center bg-neutral-900/50', className)}
     {...props}
   >
-    <Dialog.Content asChild>{children}</Dialog.Content>
+    {children}
   </Dialog.Overlay>
 );
 

--- a/src/layouts/components/HamburgerMenu/HamburgerMenu.story.tsx
+++ b/src/layouts/components/HamburgerMenu/HamburgerMenu.story.tsx
@@ -1,0 +1,22 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { HamburgerMenu } from './index';
+
+type Story = ComponentStoryObj<typeof HamburgerMenu>;
+
+const meta: ComponentMeta<typeof HamburgerMenu> = {
+  component: HamburgerMenu,
+  argTypes: {
+    className: {
+      description: 'メニューを開くボタンのサイズ等のスタイルを変更するために用意されている。`aspect-square`で縦横比が1:1に固定されています。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/layouts/components/HamburgerMenu/index.tsx
+++ b/src/layouts/components/HamburgerMenu/index.tsx
@@ -1,0 +1,37 @@
+import type { FC, ComponentPropsWithoutRef } from 'react';
+import { GiHamburgerMenu } from 'react-icons/gi';
+import { GrClose } from 'react-icons/gr';
+import { Button, ButtonIcon } from '@/components/Button';
+import type { ButtonProps } from '@/components/Button';
+import { Link } from '@/components/Link';
+import { Modal, ModalOverlay, ModalContent } from '@/components/Modal';
+import twMerge from '@/libs/twmerge';
+
+export type HamburgerMenuProps = Omit<ButtonProps, 'children'>;
+
+export const HamburgerMenu: FC<HamburgerMenuProps> = ({ className, ...props }) => (
+  <Modal
+    trigger={
+      <Button className={twMerge('', className)} {...props} ghost circle>
+        <ButtonIcon>
+          <GiHamburgerMenu />
+        </ButtonIcon>
+      </Button>
+    }
+  >
+    <ModalOverlay className="flex-col items-center justify-between bg-gradient-to-br p-8 gradient-hamburger">
+      <Button className="absolute top-6 right-6" ghost circle>
+        <ButtonIcon>
+          <GrClose />
+        </ButtonIcon>
+      </Button>
+      <ModalContent className="mt-32 w-auto items-center gap-8 bg-transparent text-2xl text-neutral-900 shadow-none">
+        <Link href="https://example.com">ランキング</Link>
+        <Link href="https://example.com">ゲーム一覧</Link>
+        <Link href="https://example.com">景品交換</Link>
+        <Link href="https://example.com">スタッフ</Link>
+      </ModalContent>
+      <span className="text-sm font-bold">画面外をタップして閉じる</span>
+    </ModalOverlay>
+  </Modal>
+);

--- a/src/layouts/components/HamburgerMenu/index.tsx
+++ b/src/layouts/components/HamburgerMenu/index.tsx
@@ -1,4 +1,4 @@
-import type { FC, ComponentPropsWithoutRef } from 'react';
+import type { FC } from 'react';
 import { GiHamburgerMenu } from 'react-icons/gi';
 import { GrClose } from 'react-icons/gr';
 import { Button, ButtonIcon } from '@/components/Button';


### PR DESCRIPTION
- close #2
- close #66

# 概要
ハンバーガーメニューを開くボタンのスタイルは外部から変更可能です。
含まれるリンクのルーティング先は仮のもののため要変更です。
Esc/Tab/Arrow Keyで操作可能です。

# 見た目
![image](https://user-images.githubusercontent.com/16751535/189477268-e71f9001-b9c4-4c80-aa4a-dead90da0596.png)
