### PR TITLE
StorybookでGoogle Fontsを読み込む`.scss`ファイルのパス指定を正しいものに修正した。

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,7 @@ import * as NextImage from 'next/image';
 // next v12以上の場合の`import`元。参照: https://www.npmjs.com/package/storybook-addon-next-router
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import 'tailwindcss/tailwind.css';
-import '../src/styles/global.scss';
+import '../src/styles/storybook.scss';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 const OriginalNextImage = NextImage.default;


### PR DESCRIPTION
- close #128 

これでStorybookでもGoogle Fontsのフォントが使用可能になります！