### PR TITLE
順位付きのユーザー情報を表示するコンポーネント`<RankedUserItem>`を作成した。

### DIFF
--- a/src/components/UserItem/index.tsx
+++ b/src/components/UserItem/index.tsx
@@ -1,8 +1,10 @@
 import type { FC, ComponentPropsWithoutRef, ReactElement } from 'react';
 import { Icon } from '@/components/Icon';
 import { Separator } from '@/components/Separator';
-import type { User } from '@/libs/graphql/generated/graphql';
+import type { User, UserBioDataFragment } from '@/libs/graphql/generated/graphql';
 import twMerge from '@/libs/twmerge';
+
+export type UserItemData = Pick<UserBioDataFragment, 'id' | 'name' | 'iconUrl'>;
 
 export type UserItemIconProps = Pick<User, 'name' | 'iconUrl'>;
 export const UserItemIcon: FC<UserItemIconProps> = ({ name, iconUrl }) => <Icon src={iconUrl} alt={`ユーザー"${name}"のアイコン画像`} />;

--- a/src/components/UserItem/index.tsx
+++ b/src/components/UserItem/index.tsx
@@ -1,12 +1,12 @@
 import type { FC, ComponentPropsWithoutRef, ReactElement } from 'react';
 import { Icon } from '@/components/Icon';
 import { Separator } from '@/components/Separator';
-import type { User, UserBioDataFragment } from '@/libs/graphql/generated/graphql';
+import type { UserBioDataFragment } from '@/libs/graphql/generated/graphql';
 import twMerge from '@/libs/twmerge';
 
 export type UserItemData = Pick<UserBioDataFragment, 'id' | 'name' | 'iconUrl'>;
 
-export type UserItemIconProps = Pick<User, 'name' | 'iconUrl'>;
+export type UserItemIconProps = Pick<UserItemData, 'name' | 'iconUrl'>;
 export const UserItemIcon: FC<UserItemIconProps> = ({ name, iconUrl }) => <Icon src={iconUrl} alt={`ユーザー"${name}"のアイコン画像`} />;
 
 export type UserItemNameProps = ComponentPropsWithoutRef<'span'>;

--- a/src/features/ranking/components/RankedUserItem/RankedUserItem.story.tsx
+++ b/src/features/ranking/components/RankedUserItem/RankedUserItem.story.tsx
@@ -1,0 +1,63 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { RankedUserItem } from './index';
+
+type Story = ComponentStoryObj<typeof RankedUserItem>;
+
+const meta: ComponentMeta<typeof RankedUserItem> = {
+  component: RankedUserItem,
+  args: {
+    id: '1',
+    name: 'ユーザー名',
+    iconUrl: '/icons/fox.png',
+    point: 50,
+    place: 7,
+    className: 'bg-white max-w-sm',
+  },
+  argTypes: {
+    id: {
+      description: 'ユーザーのIDを指定する。表示はされないが、内部でコンポーネントの`key`として使用される。',
+      control: { type: 'string' },
+    },
+    name: {
+      description: 'ユーザーの名前を指定する。',
+      control: { type: 'text' },
+    },
+    iconUrl: {
+      description: 'ユーザーのアイコンのURLを指定する。',
+      control: { type: 'text' },
+    },
+    place: {
+      description: 'ユーザーの順位を指定する。',
+      control: { type: 'number' },
+    },
+    point: {
+      description: 'ユーザーのポイントを指定する。',
+      control: { type: 'number' },
+    },
+    className: {
+      description: 'サイズを変更するために用意されている。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {};
+export const FirstPlace: Story = {
+  args: {
+    place: 1,
+  },
+};
+export const SecondPlace: Story = {
+  args: {
+    place: 2,
+  },
+};
+export const ThirdPlace: Story = {
+  args: {
+    place: 3,
+  },
+};

--- a/src/features/ranking/components/RankedUserItem/index.tsx
+++ b/src/features/ranking/components/RankedUserItem/index.tsx
@@ -1,0 +1,42 @@
+import type { FC } from 'react';
+import { FaCrown } from 'react-icons/fa';
+import { resolveDescription } from './resolveDescription';
+import { UserItem, UserItemIcon, UserItemBio, UserItemName, UserItemDescription } from '@/components/UserItem';
+import type { UserItemProps, UserItemData } from '@/components/UserItem';
+import twMerge from '@/libs/twmerge';
+
+export type RankedUserItemData = UserItemData & {
+  place: number; // 順位
+  point: number;
+};
+
+export type RankedUserItemProps = Omit<UserItemProps, 'children'> & RankedUserItemData;
+
+export const RankedUserItem: FC<RankedUserItemProps> = ({ id, name, iconUrl, place, point, className, ...props }) => {
+  const isTopThree = place === 1 || place === 2 || place === 3;
+  const description = resolveDescription({ place, point });
+  return (
+    <UserItem key={id} className={twMerge('px-3 py-2', isTopThree && 'py-4', className)} {...props}>
+      <div
+        aria-label="順位"
+        className={twMerge(
+          'flex flex-row gap-2 justify-start items-center min-w-[2rem] font-branding font-bold mr-2 text-neutral-500',
+          place === 1 && 'text-gold text-5xl',
+          place === 2 && 'text-silver text-4xl',
+          place === 3 && 'text-bronze text-4xl',
+        )}
+      >
+        {isTopThree && <FaCrown className="text-2xl" />}#{place}
+      </div>
+      <UserItemIcon iconUrl={iconUrl} name={name} />
+      <UserItemBio className={twMerge(isTopThree && 'flex-col-reverse')}>
+        <UserItemName className="text-neutral-900">{name}</UserItemName>
+        <UserItemDescription
+          className={twMerge('text-xs font-bold', place === 1 && 'text-gold', place === 2 && 'text-silver', place === 3 && 'text-bronze')}
+        >
+          {description}
+        </UserItemDescription>
+      </UserItemBio>
+    </UserItem>
+  );
+};

--- a/src/features/ranking/components/RankedUserItem/resolveDescription.spec.ts
+++ b/src/features/ranking/components/RankedUserItem/resolveDescription.spec.ts
@@ -1,0 +1,16 @@
+import { resolveDescription } from './resolveDescription';
+
+describe('resolveDescription', () => {
+  it('順位をもとに正しく説明の振り分けができる', () => {
+    expect(resolveDescription({ place: 1, point: 100 })).toBe('100 Pt を我が物とし栄冠を戴くのは...');
+    expect(resolveDescription({ place: 2, point: 100 })).toBe('100 Pt を勝ち取り、異彩を解き放つ！');
+    expect(resolveDescription({ place: 3, point: 100 })).toBe('100 Pt を集めた遊びの達人');
+    expect(resolveDescription({ place: 4, point: 100 })).toBe('100 Pt');
+  });
+  it('ポイントをもとに正しく出力される', () => {
+    expect(resolveDescription({ place: 4, point: 100 })).toBe('100 Pt');
+    expect(resolveDescription({ place: 4, point: 75 })).toBe('75 Pt');
+    expect(resolveDescription({ place: 4, point: 50 })).toBe('50 Pt');
+    expect(resolveDescription({ place: 4, point: 25 })).toBe('25 Pt');
+  });
+});

--- a/src/features/ranking/components/RankedUserItem/resolveDescription.ts
+++ b/src/features/ranking/components/RankedUserItem/resolveDescription.ts
@@ -1,0 +1,26 @@
+import type { RankedUserItemData } from '.';
+
+type ResolveDescriptionProps = Pick<RankedUserItemData, 'place' | 'point'>;
+
+type Resolver = (point: ResolveDescriptionProps['point']) => string;
+const firstPlaceResolver: Resolver = (point) => `${point} Pt を我が物とし栄冠を戴くのは...`;
+const secondPlaceResolver: Resolver = (point) => `${point} Pt を勝ち取り、異彩を解き放つ！`;
+const thirdPlaceResolver: Resolver = (point) => `${point} Pt を集めた遊びの達人`;
+const defaultResolver: Resolver = (point) => `${point} Pt`;
+
+export const resolveDescription = ({ place, point }: ResolveDescriptionProps): string => {
+  switch (place) {
+    case 1:
+      return firstPlaceResolver(point);
+      break;
+    case 2:
+      return secondPlaceResolver(point);
+      break;
+    case 3:
+      return thirdPlaceResolver(point);
+      break;
+    default:
+      return defaultResolver(point);
+      break;
+  }
+};


### PR DESCRIPTION
- close #146 
- close #152 

# 概要
順位とポイントとユーザー情報を受け取る`<UserItem>`のラッパーです。
特筆すべきことはないと思います...
![image](https://user-images.githubusercontent.com/16751535/193258740-f8f60779-4a0f-452c-bf42-875a9c49cca2.png)
![image](https://user-images.githubusercontent.com/16751535/193258758-8f9ce115-e02f-4ea5-ad5b-9e9a2d65f21c.png)
![image](https://user-images.githubusercontent.com/16751535/193258775-61283d6f-ff2b-49e8-8013-aa5235bf3f65.png)
![image](https://user-images.githubusercontent.com/16751535/193258799-37854edf-c33d-41cc-aa3e-de825dbd4325.png)
