### PR TITLE
Storybookで読み込まれる`.scss`ファイルに、Figma準拠のデフォルトのフォント指定を追加した。

### DIFF
--- a/src/styles/storybook.scss
+++ b/src/styles/storybook.scss
@@ -1,2 +1,7 @@
 // StorybookでGoogle Fontsを読み込むためのscssファイル
 @import url('https://fonts.googleapis.com/css2?family=DotGothic16&family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&family=Oxygen:wght@400;700&family=Press+Start+2P&display=swap');
+
+html,
+body {
+  font-family: Inter, 'Noto Sans JP', sans-serif;
+}


### PR DESCRIPTION
- close #153

これでStorybookでのフォント表示が、細長いださいフォントじゃなくなります。 