### PR TITLE
`graphql-codegen`が生成するGraphQLのスカラー`DateTime`に対応するTypescriptの型が`any`から`Date`になるように変更した。

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -3,6 +3,9 @@ schema: ${NEXT_PUBLIC_GRAPHQL_ENDPOINT}
 documents: 'src/libs/graphql/documents/**/*.gql'
 generates:
   src/libs/graphql/generated/graphql.ts:
+    config:
+      scalars:
+        DateTime: unknown
     plugins:
       - 'typescript'
       - 'typescript-operations'

--- a/codegen.yml
+++ b/codegen.yml
@@ -5,7 +5,7 @@ generates:
   src/libs/graphql/generated/graphql.ts:
     config:
       scalars:
-        DateTime: unknown
+        DateTime: Date
     plugins:
       - 'typescript'
       - 'typescript-operations'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "sharp": "0.31.0",
     "tailwind-merge": "1.6.0",
     "tailwindcss": "3.1.8",
-    "urql": "3.0.3"
+    "urql": "3.0.3",
+    "urql-custom-scalars-exchange": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.19.1",

--- a/src/libs/graphql/generated/graphql.ts
+++ b/src/libs/graphql/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  DateTime: any;
+  DateTime: unknown;
 };
 
 export type BoolFilter = {
@@ -71,6 +71,16 @@ export enum Game {
   WeDidntPlaytest = 'WE_DIDNT_PLAYTEST',
   Xeno = 'XENO'
 }
+
+export type GameAttenders = {
+  __typename?: 'GameAttenders';
+  coin_dropping: Array<User>;
+  ice_raze: Array<User>;
+  poker: Array<User>;
+  president: Array<User>;
+  we_didnt_playtest: Array<User>;
+  xeno: Array<User>;
+};
 
 export type Gift = {
   __typename?: 'Gift';
@@ -321,6 +331,12 @@ export type NestedStringFilter = {
   startsWith?: InputMaybe<Scalars['String']>;
 };
 
+export type ObtainmentStatus = {
+  __typename?: 'ObtainmentStatus';
+  item: Item;
+  obtained: Scalars['Boolean'];
+};
+
 export type Query = {
   __typename?: 'Query';
   findGift?: Maybe<Gift>;
@@ -329,6 +345,7 @@ export type Query = {
   findGifts: Array<Gift>;
   findUser?: Maybe<User>;
   findUsers: Array<User>;
+  getObtainmentStatuses: Array<ObtainmentStatus>;
 };
 
 
@@ -373,6 +390,11 @@ export type QueryFindUsersArgs = {
   where?: InputMaybe<UserWhereInput>;
 };
 
+
+export type QueryGetObtainmentStatusesArgs = {
+  where: UserWhereUniqueInput;
+};
+
 export enum QueryMode {
   Default = 'default',
   Insensitive = 'insensitive'
@@ -411,6 +433,11 @@ export type StringNullableListFilter = {
   isEmpty?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type Subscription = {
+  __typename?: 'Subscription';
+  updatedGameAttenders: GameAttenders;
+};
+
 export type User = {
   __typename?: 'User';
   avatarUrl: Scalars['String'];
@@ -432,10 +459,8 @@ export type User = {
 };
 
 export type UserCreateInput = {
-  avatarUrl: Scalars['String'];
   character: Character;
   email: Scalars['String'];
-  iconUrl: Scalars['String'];
   id: Scalars['String'];
   name: Scalars['String'];
   role?: InputMaybe<Role>;
@@ -513,7 +538,7 @@ export type FindUserQueryVariables = Exact<{
 }>;
 
 
-export type FindUserQuery = { __typename?: 'Query', findUser?: { __typename?: 'User', id: string, name: string, email: string, role: Role, character: Character, avatarUrl: string, iconUrl: string, participateGame: Game, pullableGachaTimes: number, totalPointDay1: number, totalPointDay2: number, consumablePoint: number, items: Array<{ __typename?: 'Item', id: string, layer: number, url: string }>, giftHistories: Array<{ __typename?: 'GiftHistory', id: string, giftId: string, isDelivered: boolean, createdAt: any }> } | null };
+export type FindUserQuery = { __typename?: 'Query', findUser?: { __typename?: 'User', id: string, name: string, email: string, role: Role, character: Character, avatarUrl: string, iconUrl: string, participateGame: Game, pullableGachaTimes: number, totalPointDay1: number, totalPointDay2: number, consumablePoint: number, items: Array<{ __typename?: 'Item', id: string, layer: number, url: string }>, giftHistories: Array<{ __typename?: 'GiftHistory', id: string, giftId: string, isDelivered: boolean, createdAt: unknown }> } | null };
 
 export type FindUserBioQueryVariables = Exact<{
   id: Scalars['String'];

--- a/src/libs/graphql/generated/graphql.ts
+++ b/src/libs/graphql/generated/graphql.ts
@@ -13,7 +13,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  DateTime: unknown;
+  DateTime: Date;
 };
 
 export type BoolFilter = {
@@ -538,7 +538,7 @@ export type FindUserQueryVariables = Exact<{
 }>;
 
 
-export type FindUserQuery = { __typename?: 'Query', findUser?: { __typename?: 'User', id: string, name: string, email: string, role: Role, character: Character, avatarUrl: string, iconUrl: string, participateGame: Game, pullableGachaTimes: number, totalPointDay1: number, totalPointDay2: number, consumablePoint: number, items: Array<{ __typename?: 'Item', id: string, layer: number, url: string }>, giftHistories: Array<{ __typename?: 'GiftHistory', id: string, giftId: string, isDelivered: boolean, createdAt: unknown }> } | null };
+export type FindUserQuery = { __typename?: 'Query', findUser?: { __typename?: 'User', id: string, name: string, email: string, role: Role, character: Character, avatarUrl: string, iconUrl: string, participateGame: Game, pullableGachaTimes: number, totalPointDay1: number, totalPointDay2: number, consumablePoint: number, items: Array<{ __typename?: 'Item', id: string, layer: number, url: string }>, giftHistories: Array<{ __typename?: 'GiftHistory', id: string, giftId: string, isDelivered: boolean, createdAt: Date }> } | null };
 
 export type FindUserBioQueryVariables = Exact<{
   id: Scalars['String'];

--- a/src/libs/graphql/schema.json
+++ b/src/libs/graphql/schema.json
@@ -6,7 +6,9 @@
     "mutationType": {
       "name": "Mutation"
     },
-    "subscriptionType": null,
+    "subscriptionType": {
+      "name": "Subscription"
+    },
     "types": [
       {
         "kind": "INPUT_OBJECT",
@@ -519,6 +521,161 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GameAttenders",
+        "description": null,
+        "fields": [
+          {
+            "name": "coin_dropping",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ice_raze",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "poker",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "president",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "we_didnt_playtest",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "xeno",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -2933,6 +3090,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ObtainmentStatus",
+        "description": null,
+        "fields": [
+          {
+            "name": "item",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Item",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "obtained",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Query",
         "description": null,
         "fields": [
@@ -3301,6 +3501,47 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "getObtainmentStatuses",
+            "description": null,
+            "args": [
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UserWhereUniqueInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ObtainmentStatus",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -3655,6 +3896,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "Subscription",
+        "description": null,
+        "fields": [
+          {
+            "name": "updatedGameAttenders",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GameAttenders",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "User",
         "description": null,
         "fields": [
@@ -3951,22 +4219,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "avatarUrl",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "character",
             "description": null,
             "type": {
@@ -3984,22 +4236,6 @@
           },
           {
             "name": "email",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "iconUrl",
             "description": null,
             "type": {
               "kind": "NON_NULL",

--- a/src/libs/urql/index.ts
+++ b/src/libs/urql/index.ts
@@ -3,13 +3,14 @@ import { authExchange } from '@urql/exchange-auth';
 import { createClient as createWsClient } from 'graphql-ws';
 import { createClient, ClientOptions, cacheExchange, dedupExchange, fetchExchange, subscriptionExchange, Exchange } from 'urql';
 import authConfig from './authConfig';
+import { scalarsExchange } from './scalarsExchange';
 
 const url = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT_DEVELOP || process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT;
 if (!url) {
   throw new Error('"NEXT_PUBLIC_GRAPHQL_ENDPOINT" または "NEXT_PUBLIC_GRAPHQL_ENDPOINT_DEVELOP"は必須の環境変数です.');
 }
 
-const exchanges: Exchange[] = [devtoolsExchange, dedupExchange, cacheExchange, authExchange(authConfig), fetchExchange];
+const exchanges: Exchange[] = [devtoolsExchange, dedupExchange, scalarsExchange, cacheExchange, authExchange(authConfig), fetchExchange];
 
 if (typeof window !== 'undefined') {
   const wsUrl = process.env.NEXT_PUBLIC_WS_ENDPOINT_DEVELOP || process.env.NEXT_PUBLIC_WS_ENDPOINT;

--- a/src/libs/urql/scalarsExchange.ts
+++ b/src/libs/urql/scalarsExchange.ts
@@ -1,0 +1,15 @@
+import { parseISO } from 'date-fns';
+import type { IntrospectionQuery } from 'graphql';
+import customScalarsExchange from 'urql-custom-scalars-exchange';
+import schema from '@/libs/graphql/schema.json';
+
+//
+// 参照: https://github.com/clentfort/urql-custom-scalars-exchange
+//
+
+export const scalarsExchange = customScalarsExchange({
+  schema: schema as unknown as IntrospectionQuery,
+  scalars: {
+    DateTime: (value: unknown) => (typeof value === 'string' ? parseISO(value) : new Date(0)),
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15167,6 +15167,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+urql-custom-scalars-exchange@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/urql-custom-scalars-exchange/-/urql-custom-scalars-exchange-1.0.1.tgz#b89db93f5943932e0f8d67a500e35da4449e98c8"
+  integrity sha512-NSxUaw1ZWu72iJ/t4qy6hbm33HKthIglLl8JzHEtEQgE1ICxl5kXmzmZWL5ycxlNRgCOvU2nqzrplIhBo7q3UQ==
+
 urql@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/urql/-/urql-3.0.3.tgz#275631f487558354e090d9ffc4ea2030bd56c34a"


### PR DESCRIPTION
- close #155 

> `any`だと何でもできて怖いから変えたいです

[公式のShowcaseで紹介されている`urql-custom-scalars-exchange`](https://github.com/clentfort/urql-custom-scalars-exchange)を用いて、
GraphQLのカスタムスカラー`DateTime`として受け取る、ISO8601で日付時刻を表す`string`を、パースして`Date`に解決するURQLのExchangeを追加しました。