### PR TITLE
テキストフィールド型の入力欄を提供する`<Input>`と、それに付随する情報を表すコンポーネント群`<InputItem>` `<InputLabel>` `<InputMessage>`を作成した。

### DIFF
--- a/src/components/Input/Input.story.tsx
+++ b/src/components/Input/Input.story.tsx
@@ -61,11 +61,17 @@ export const WithAdditionalInfo: Story = {
           <InputLabelName>名前</InputLabelName>
           <InputLabelDescription>他のユーザーから見えるあなたの表示名になります</InputLabelDescription>
         </InputLabel>
+        <InputMessage>公共の場にふさわしくない名前をつけた場合、利用停止になる可能性があります</InputMessage>
         <Input ref={inputRef} onChange={forceUpdate} {...args} />
-        <InputMessage isVisible={valueMissing}>名前を入力してください</InputMessage>
-        <InputMessage isVisible={valid}>この名前は使用可能です</InputMessage>
-        <InputMessage isVisible={!valid && !valueMissing}>この名前はすでに使われています</InputMessage>
-        <InputMessage informative>公共の場にふさわしくない名前をつけた場合、利用停止になる可能性があります</InputMessage>
+        <InputMessage type="error" on={valueMissing}>
+          名前を入力してください
+        </InputMessage>
+        <InputMessage type="success" on={valid}>
+          この名前は使用可能です
+        </InputMessage>
+        <InputMessage type="error" on={!valid && !valueMissing}>
+          この名前はすでに使われています
+        </InputMessage>
       </InputItem>
     );
   },

--- a/src/components/Input/Input.story.tsx
+++ b/src/components/Input/Input.story.tsx
@@ -1,0 +1,72 @@
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { Input, InputItem, InputMessage, InputLabel, InputLabelName, InputLabelDescription, useInputValidityState } from './index';
+
+type Story = ComponentStoryObj<typeof Input>;
+
+const meta: ComponentMeta<typeof Input> = {
+  component: Input,
+  args: {
+    placeholder: 'ここに入力してください',
+  },
+  argTypes: {
+    type: {
+      description: 'HTML準拠の`<input>`の入力タイプです。このコンポーネントでは、テキストフィールド型のUIを持つもののみ使用可能にしています。',
+      control: { type: 'select', options: ['text', 'password', 'email', 'number'] },
+    },
+    required: {
+      description: 'HTML準拠の`<input>`の属性です。空欄を許容するかどうかを指定します。',
+      control: { type: 'boolean' },
+    },
+    placeholder: {
+      description: 'HTML準拠の`<input>`の属性です。入力欄に何も入力されていないときに表示される文字列です。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {};
+
+export const Invalid: Story = {
+  args: {
+    type: 'email',
+    value: 'user_example.com',
+    placeholder: '(例) user@example.com',
+    required: true,
+  },
+};
+
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+};
+
+export const WithAdditionalInfo: Story = {
+  args: {
+    placeholder: '(例) やまだたろう',
+    defaultValue: 'やまだ',
+    required: true,
+  },
+  render: (args) => {
+    // Storybookの`render`関数がReactのコンポーネントの命名規則であるPascalCaseを満たしていないから、無効化する
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { inputRef, validityState, forceUpdate } = useInputValidityState();
+    const { valid, valueMissing } = validityState;
+    return (
+      <InputItem className="max-w-md">
+        <InputLabel>
+          <InputLabelName>名前</InputLabelName>
+          <InputLabelDescription>他のユーザーから見えるあなたの表示名になります</InputLabelDescription>
+        </InputLabel>
+        <Input ref={inputRef} onChange={forceUpdate} {...args} />
+        <InputMessage isVisible={valueMissing}>名前を入力してください</InputMessage>
+        <InputMessage isVisible={valid}>この名前は使用可能です</InputMessage>
+        <InputMessage isVisible={!valid && !valueMissing}>この名前はすでに使われています</InputMessage>
+        <InputMessage informative>公共の場にふさわしくない名前をつけた場合、利用停止になる可能性があります</InputMessage>
+      </InputItem>
+    );
+  },
+};

--- a/src/components/Input/hooks/useInputValidityState.ts
+++ b/src/components/Input/hooks/useInputValidityState.ts
@@ -1,0 +1,43 @@
+import { useReducer, useCallback, useState } from 'react';
+
+//
+// `<input>`の入力された値に基づく状態を表す`ValidityState`
+// 参照: https://developer.mozilla.org/ja/docs/Web/API/ValidityState
+//
+export type InputValidityState = HTMLInputElement['validity'];
+
+export const useInputValidityState = () => {
+  const [validityState, setValidityState] = useState<InputValidityState>({
+    badInput: false,
+    customError: false,
+    patternMismatch: false,
+    rangeOverflow: false,
+    rangeUnderflow: false,
+    stepMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    typeMismatch: false,
+    valueMissing: false,
+    valid: true,
+  });
+  //
+  // `<input>`の入力値が`value`と`onChange`を使って管理されていない時(=`uncontrolled`な時)、入力値が更新されても再レンダリングされない。
+  // しかし、`<input>`の状態に依って表示を変える下記の`<InputMessage>`と併用する場合、変更に合わせて再レンダリングする必要がある。
+  // そのような場合のために、Reactでuncontrolledな`<input>`の入力値が更新されたときにコンポーネントを再レンダリングするための関数`forceUpdate`を提供する
+  // 参照: https://ja.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+  //
+  const [, forceUpdate] = useReducer((x) => !x, false);
+  const inputRef = useCallback(
+    (inputNode: HTMLInputElement) => {
+      if (inputNode) {
+        setValidityState(inputNode.validity);
+      }
+    },
+    [setValidityState],
+  );
+  return {
+    inputRef,
+    validityState,
+    forceUpdate,
+  };
+};

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,90 @@
+import { FC, ComponentPropsWithoutRef, ComponentPropsWithRef, ReactElement, forwardRef } from 'react';
+import { useInputValidityState } from './hooks/useInputValidityState';
+import { Label, LabelProps } from '@/components/Label';
+import twMerge from '@/libs/twmerge';
+
+// 外部からの`import`のしやすさのために、このファイル`index.tsx`から`export`しなおす
+export { useInputValidityState };
+
+// `<input>`の入力された値に基づく状態を表す`ValidityState`を取得するためにRefを受け取れるようにする
+export type InputProps = Omit<ComponentPropsWithRef<'input'>, 'type'> & {
+  type: 'text' | 'password' | 'email' | 'number';
+};
+export const Input: FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(({ required, placeholder, className, ...props }, ref) => {
+  let text = placeholder;
+  if (required) {
+    if (placeholder) {
+      text = `(必須) ${placeholder}`;
+    } else {
+      text = `(必須)`;
+    }
+  }
+  return (
+    <input
+      ref={ref}
+      {...props}
+      required={required}
+      placeholder={text}
+      className={twMerge(
+        'peer px-6 py-3 rounded-base placeholder:text-neutral-400 shadow-z8 focus:shadow-z16 outline-none duration-75 border-2 border-neutral-200 bg-white focus:valid:border-success-700 focus:valid:text-success-700 invalid:border-error-700 invalid:text-error-700',
+        className,
+      )}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export type InputLabelNameProps = ComponentPropsWithoutRef<'span'>;
+export const InputLabelName: FC<InputLabelNameProps> = ({ children, className, ...props }) => (
+  <span className={twMerge('font-branding font-bold flex-grow-0 flex-shrink-0', className)} {...props}>
+    {children}
+  </span>
+);
+
+export type InputLabelDescriptionProps = ComponentPropsWithoutRef<'span'>;
+export const InputLabelDescription: FC<InputLabelNameProps> = ({ children, className, ...props }) => (
+  <span className={twMerge('text-neutral-500 flex-grow text-right', className)} {...props}>
+    {children}
+  </span>
+);
+
+export type InputLabelProps = ComponentPropsWithoutRef<'div'> & {
+  children: Array<ReactElement<InputLabelNameProps> | ReactElement<InputLabelDescriptionProps>> | ReactElement<InputLabelNameProps>;
+};
+export const InputLabel: FC<InputLabelProps> = ({ className, children, ...props }) => (
+  <div className={twMerge('flex flex-row justify-between items-center gap-2', className)} {...props}>
+    {children}
+  </div>
+);
+
+export type InputMessageProps = ComponentPropsWithoutRef<'div'> & {
+  isVisible?: boolean;
+  informative?: boolean; // 見た目を情報的なものを示す青色に固定する
+};
+export const InputMessage: FC<InputMessageProps> = ({ isVisible, informative, children, className, ...props }) =>
+  isVisible ? (
+    <div
+      className={twMerge(
+        'px-4 py-2 flex flex-row justify-start border-2 text-info-700 border-info-200 items-center rounded-base bg-gradient-to-br from-white to-info-100',
+        !informative && 'peer-valid:visible peer-valid:to-success-100 peer-valid:border-success-200 peer-valid:text-success-700',
+        !informative && 'peer-invalid:visible peer-invalid:to-error-100 peer-invalid:border-error-200 peer-invalid:text-error-700',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  ) : null;
+InputMessage.defaultProps = {
+  isVisible: true,
+  informative: false,
+};
+
+export type InputItemProps = LabelProps & {
+  children: Array<ReactElement<InputLabelProps> | ReactElement<InputProps> | ReactElement<InputMessageProps>>;
+};
+export const InputItem: FC<InputItemProps> = ({ children, className, ...props }) => (
+  <Label className={twMerge('flex w-fit flex-col gap-1', className)} {...props}>
+    {children}
+  </Label>
+);

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,8 +1,8 @@
 import { FC, ComponentPropsWithoutRef, ComponentPropsWithRef, ReactElement, forwardRef } from 'react';
+import { RiInformationFill, RiCheckboxCircleFill, RiErrorWarningFill } from 'react-icons/ri';
 import { useInputValidityState } from './hooks/useInputValidityState';
 import { Label, LabelProps } from '@/components/Label';
 import twMerge from '@/libs/twmerge';
-
 // 外部からの`import`のしやすさのために、このファイル`index.tsx`から`export`しなおす
 export { useInputValidityState };
 
@@ -20,16 +20,24 @@ export const Input: FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(({
     }
   }
   return (
-    <input
-      ref={ref}
-      {...props}
-      required={required}
-      placeholder={text}
-      className={twMerge(
-        'peer px-6 py-3 rounded-base placeholder:text-neutral-400 shadow-z8 focus:shadow-z16 outline-none duration-75 border-2 border-neutral-200 bg-white focus:valid:border-success-700 focus:valid:text-success-700 invalid:border-error-700 invalid:text-error-700',
-        className,
-      )}
-    />
+    <div className="grid grid-cols-1 grid-rows-1">
+      <input
+        ref={ref}
+        {...props}
+        required={required}
+        placeholder={text}
+        className={twMerge(
+          'col-span-full row-span-full peer px-6 py-3 rounded-base placeholder:text-neutral-400 shadow-z8 focus:shadow-z16 outline-none duration-75 border-2 border-neutral-200 bg-white focus:valid:border-success-700 focus:valid:text-success-700 invalid:border-error-700 invalid:text-error-700',
+          className,
+        )}
+      />
+      <div className="pointer-events-none col-span-full row-span-full m-0 hidden items-center justify-end p-0 px-4 text-2xl text-success-700 peer-valid:flex">
+        <RiCheckboxCircleFill />
+      </div>
+      <div className="pointer-events-none col-span-full row-span-full m-0 hidden items-center justify-end p-0 px-4 text-2xl text-error-700 peer-invalid:flex">
+        <RiErrorWarningFill />
+      </div>
+    </div>
   );
 });
 Input.displayName = 'Input';
@@ -58,33 +66,40 @@ export const InputLabel: FC<InputLabelProps> = ({ className, children, ...props 
 );
 
 export type InputMessageProps = ComponentPropsWithoutRef<'div'> & {
-  isVisible?: boolean;
-  informative?: boolean; // 見た目を情報的なものを示す青色に固定する
+  on?: boolean;
+  type?: 'info' | 'success' | 'error'; // メッセージの種類と見た目を規定する
 };
-export const InputMessage: FC<InputMessageProps> = ({ isVisible, informative, children, className, ...props }) =>
-  isVisible ? (
+export const InputMessage: FC<InputMessageProps> = ({ on, type, children, className, ...props }) =>
+  on ? (
     <div
       className={twMerge(
-        'px-4 py-2 flex flex-row justify-start border-2 text-info-700 border-info-200 items-center rounded-base bg-gradient-to-br from-white to-info-100',
-        !informative && 'peer-valid:visible peer-valid:to-success-100 peer-valid:border-success-200 peer-valid:text-success-700',
-        !informative && 'peer-invalid:visible peer-invalid:to-error-100 peer-invalid:border-error-200 peer-invalid:text-error-700',
+        'flex flex-row justify-start items-center rounded-base',
+        type !== 'info' && 'flex text-right justify-end peer-valid:text-success-700 peer-invalid:text-error-700',
+        type === 'success' && 'text-success-700',
+        type === 'error' && 'text-error-700',
+        type === 'info' && 'px-4 py-2 gap-2 text-info-700 bg-info-100',
         className,
       )}
       {...props}
     >
+      {type === 'info' && (
+        <span className="text-2xl">
+          <RiInformationFill />
+        </span>
+      )}
       {children}
     </div>
   ) : null;
 InputMessage.defaultProps = {
-  isVisible: true,
-  informative: false,
+  on: true,
+  type: 'info',
 };
 
 export type InputItemProps = LabelProps & {
   children: Array<ReactElement<InputLabelProps> | ReactElement<InputProps> | ReactElement<InputMessageProps>>;
 };
 export const InputItem: FC<InputItemProps> = ({ children, className, ...props }) => (
-  <Label className={twMerge('flex w-fit flex-col gap-1', className)} {...props}>
+  <Label className={twMerge('group flex w-fit flex-col justify-start items-stretch gap-1', className)} {...props}>
     {children}
   </Label>
 );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,7 +72,7 @@ const config = {
           DEFAULT: '#01a037',
           400: '#02bc42',
           300: '#01d94d',
-          200: '#40fb68',
+          200: '#7BEB93',
           100: '#d0fccf',
         },
         warning: {


### PR DESCRIPTION
- close #158 

# 概要
`<Input>`はただのスタイル付きのHTML`<input>`ラッパーです。
ですが、テキストフィールド型のもののみ使用可能にするために、利用可能な`type`を制限しています
Storybookを参照してください！！！