### PR TITLE
缶バッジ交換履歴ページ用の、缶バッジの取引情報を表すコンポーネント`<BadgeTransactionItem>`を作成した

### DIFF
--- a/src/features/history/components/BadgeTransactionItem/BadgeTransactionItem.story.tsx
+++ b/src/features/history/components/BadgeTransactionItem/BadgeTransactionItem.story.tsx
@@ -1,0 +1,67 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+import { BadgeTransactionItem } from './index';
+import { Character } from '@/libs/graphql/generated/graphql';
+
+type Story = ComponentStoryObj<typeof BadgeTransactionItem>;
+
+const meta: ComponentMeta<typeof BadgeTransactionItem> = {
+  component: BadgeTransactionItem,
+  args: {
+    id: 'this-is-transaction-id-12345',
+    isDelivered: false,
+    createdAt: new Date(),
+    deliveredAt: new Date(),
+    user: {
+      name: 'ユーザー名',
+      iconUrl: '/icons/fox.png',
+    },
+    exchangedBadge: Character.Fox,
+    className: 'max-w-3xl',
+  },
+  argTypes: {
+    id: {
+      description: '缶バッジとの交換の取引(`GiftHistory`)のIDを指定する。表示はされないが、内部でコンポーネントの`key`として使用される。',
+      control: { type: 'string' },
+    },
+    isDelivered: {
+      description: '缶バッジが受け渡し済みかどうかを指定する。',
+      control: { type: 'boolean' },
+    },
+    createdAt: {
+      description: '缶バッジとの交換の取引が作成された日時を指定する。',
+      control: { type: 'date' },
+    },
+    deliveredAt: {
+      description: '缶バッジが受け渡し済みになった日時を指定する。',
+      control: { type: 'date' },
+    },
+    user: {
+      description: '交換の取引を行ったユーザーの情報を指定できる。',
+      control: { type: 'object' },
+    },
+    exchangedBadge: {
+      description: '交換される缶バッジのキャラクターの種類を指定できる。省略された場合、缶バッジの詳細は表示されない。',
+      control: { type: 'select', options: [undefined, ...Object.values(Character)] },
+    },
+    onSubmit: {
+      description:
+        '対象との缶バッジの取引を受け渡し済みにする、もしくは取り消すボタンを押したときに、その`id`と新しい状態`isDelivered`とともに呼び出されるイベントハンドラを指定する。',
+      control: { type: 'function' },
+    },
+    className: {
+      description: 'サイズを変更するために用意されている。',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {};
+
+export const WithoutDetail: Story = {
+  args: {
+    exchangedBadge: undefined,
+  },
+};

--- a/src/features/history/components/BadgeTransactionItem/index.tsx
+++ b/src/features/history/components/BadgeTransactionItem/index.tsx
@@ -1,0 +1,28 @@
+import type { FC } from 'react';
+import { IoMdSwap } from 'react-icons/io';
+import { Icon } from '@/components/Icon';
+import { TransactionItem, TransactionItemProps } from '@/components/TransactionItem';
+import type { UserItemData } from '@/components/UserItem';
+import type { Character } from '@/libs/graphql/generated/graphql';
+
+import { CharacterIconUrlDictionary, CharacterNameDictionary } from '@/utils/characterDictionary';
+
+export type BadgeTransactionItemData = UserItemData & {
+  exchangedBadge?: Character;
+};
+
+export type BadgeTransactionItemProps = Omit<TransactionItemProps, 'children'> & BadgeTransactionItemData;
+export const BadgeTransactionItem: FC<BadgeTransactionItemProps> = ({ exchangedBadge, ...props }) => (
+  <TransactionItem {...props}>
+    {!!exchangedBadge && (
+      <>
+        <IoMdSwap className="text-lg text-neutral-500" />
+        <Icon className="inline h-6" src={CharacterIconUrlDictionary[exchangedBadge]} />
+        {`${CharacterNameDictionary[exchangedBadge]} の缶バッジ`}
+      </>
+    )}
+  </TransactionItem>
+);
+BadgeTransactionItem.defaultProps = {
+  exchangedBadge: undefined,
+};

--- a/src/utils/characterDictionary.ts
+++ b/src/utils/characterDictionary.ts
@@ -1,0 +1,19 @@
+import { Character } from '@/libs/graphql/generated/graphql';
+
+export const CharacterNameDictionary: Record<Character, string> = {
+  [Character.Fox]: 'きゅうびさん',
+  [Character.Cat]: 'ねこさん',
+  [Character.Pudding]: 'あらもーちゃん',
+  [Character.Reaper]: 'りっぱーさん',
+  [Character.Tree]: 'おおもりさん',
+  [Character.Goku]: 'ごくうさん',
+};
+
+export const CharacterIconUrlDictionary: Record<Character, string> = {
+  [Character.Fox]: '/icons/fox.png',
+  [Character.Cat]: '/icons/cat.png',
+  [Character.Pudding]: '/icons/pudding.png',
+  [Character.Reaper]: '/icons/reaper.png',
+  [Character.Tree]: '/icons/tree.png',
+  [Character.Goku]: '/icons/goku.png',
+};


### PR DESCRIPTION
- close #161 