### PR TITLE
各コンポーネント内の`<Link>`の宛先`href`を正しいサイト内のルーティングのものに修正した。

### DIFF
--- a/src/layouts/components/HamburgerMenu/index.tsx
+++ b/src/layouts/components/HamburgerMenu/index.tsx
@@ -26,10 +26,10 @@ export const HamburgerMenu: FC<HamburgerMenuProps> = ({ className, ...props }) =
         </ButtonIcon>
       </Button>
       <ModalContent className="mt-32 w-auto items-center gap-8 bg-transparent text-2xl text-neutral-900 shadow-none">
-        <Link href="https://example.com">ランキング</Link>
-        <Link href="https://example.com">ゲーム一覧</Link>
-        <Link href="https://example.com">景品交換</Link>
-        <Link href="https://example.com">スタッフ</Link>
+        <Link href="/ranking">ランキング</Link>
+        <Link href="/games">ゲーム一覧</Link>
+        <Link href="/gifts">景品交換</Link>
+        <Link href="/staff">スタッフ</Link>
       </ModalContent>
       <span className="text-sm font-bold">画面外をタップして閉じる</span>
     </ModalOverlay>

--- a/src/layouts/components/PageNavigationMenu/index.tsx
+++ b/src/layouts/components/PageNavigationMenu/index.tsx
@@ -11,35 +11,35 @@ export const PageNavigationMenu: FC<PageNavigationMenuProps> = ({ className, ...
   <NavigationMenu className={twMerge('p-0 flex flex-row justify-center gap-4 items-center', className)} {...props}>
     <NavigationItem className="hidden shrink-0 grow basis-24 items-center justify-center whitespace-nowrap md:flex">
       <NavigationLink>
-        <Link className="text-center text-neutral-700 drop-shadow-none" href="https://example.com">
+        <Link className="text-center text-neutral-700 drop-shadow-none" href="/ranking">
           ランキング
         </Link>
       </NavigationLink>
     </NavigationItem>
     <NavigationItem className="hidden shrink-0 grow basis-24 items-center justify-center whitespace-nowrap md:flex">
       <NavigationLink>
-        <Link className="text-center text-neutral-700 drop-shadow-none" href="https://example.com">
+        <Link className="text-center text-neutral-700 drop-shadow-none" href="/games">
           ゲーム一覧
         </Link>
       </NavigationLink>
     </NavigationItem>
     <NavigationItem className="flex flex-1 items-center justify-center md:px-4">
       <NavigationLink>
-        <Link className="relative flex h-full w-14 flex-none items-center justify-center drop-shadow-none" href="https://example.com">
+        <Link className="relative flex h-full w-14 flex-none items-center justify-center drop-shadow-none" href="/">
           <Image src="/logos/header.png" width={324} height={284} alt="OZ at 3Iのロゴ画像" />
         </Link>
       </NavigationLink>
     </NavigationItem>
     <NavigationItem className="hidden shrink-0 grow basis-24 items-center justify-center whitespace-nowrap md:flex">
       <NavigationLink>
-        <Link className="text-center text-neutral-700 drop-shadow-none" href="https://example.com">
+        <Link className="text-center text-neutral-700 drop-shadow-none" href="/gifts">
           景品交換
         </Link>
       </NavigationLink>
     </NavigationItem>
     <NavigationItem className="hidden shrink-0 grow basis-24 items-center justify-center whitespace-nowrap md:flex">
       <NavigationLink>
-        <Link className="text-center text-neutral-700 drop-shadow-none" href="https://example.com">
+        <Link className="text-center text-neutral-700 drop-shadow-none" href="/staff">
           スタッフ
         </Link>
       </NavigationLink>

--- a/src/layouts/components/UserNavigationMenu/index.tsx
+++ b/src/layouts/components/UserNavigationMenu/index.tsx
@@ -48,7 +48,7 @@ export const UserNavigationMenu: FC<UserNavigationMenuProps & UserNavigationMenu
           {isLoggedIn ? (
             <>
               <NavigationLink>
-                <Link className="gap-2 font-normal" href="https://example.com">
+                <Link className="gap-2 font-normal" href="/profile">
                   <LinkIcon>
                     <FaUserCircle />
                   </LinkIcon>
@@ -56,7 +56,7 @@ export const UserNavigationMenu: FC<UserNavigationMenuProps & UserNavigationMenu
                 </Link>
               </NavigationLink>
               <NavigationLink>
-                <Link className="gap-2 font-normal" href="https://example.com">
+                <Link className="gap-2 font-normal" href="/auth/sign-out">
                   <LinkIcon>
                     <ImExit />
                   </LinkIcon>
@@ -66,7 +66,7 @@ export const UserNavigationMenu: FC<UserNavigationMenuProps & UserNavigationMenu
             </>
           ) : (
             <NavigationLink>
-              <Link className="gap-2 font-normal" href="https://example.com">
+              <Link className="gap-2 font-normal" href="/auth/sign-up">
                 <LinkIcon>
                   <RiUser3Fill />
                 </LinkIcon>
@@ -78,7 +78,7 @@ export const UserNavigationMenu: FC<UserNavigationMenuProps & UserNavigationMenu
             <>
               <hr className="m-0 h-px w-full bg-neutral-200" />
               <NavigationLink>
-                <Link className="gap-2 font-normal" href="https://example.com">
+                <Link className="gap-2 font-normal" href="/admin/game">
                   <LinkIcon>
                     <TbClipboardText />
                   </LinkIcon>
@@ -86,7 +86,7 @@ export const UserNavigationMenu: FC<UserNavigationMenuProps & UserNavigationMenu
                 </Link>
               </NavigationLink>
               <NavigationLink>
-                <Link className="gap-2 font-normal" href="https://example.com">
+                <Link className="gap-2 font-normal" href="/admin/history">
                   <LinkIcon>
                     <BiTimeFive />
                   </LinkIcon>


### PR DESCRIPTION
- close #180 

テスト用の`https://example.com`はリンクの宛先から消滅しました。