### PR TITLE
RecoilのAtom`AudioResource`の値に応じて再生する曲を切り替え、`<audio>`タグの`ref`の共有と自動再生の管理を担うコンポーネント`<AudioProvider>`を作成する。

### DIFF
--- a/src/layouts/Layout.story.tsx
+++ b/src/layouts/Layout.story.tsx
@@ -25,6 +25,8 @@ const injectedHooks = [
         name: '作曲者名',
       },
     ],
+    duration: 100,
+    currentTime: 0,
   })),
 ];
 

--- a/src/layouts/Layout.story.tsx
+++ b/src/layouts/Layout.story.tsx
@@ -17,7 +17,8 @@ const injectedHooks = [
   })),
   injectable(useAudioControlMenu, () => ({
     isPlaying: false,
-    setIsPlaying: () => {},
+    onPlay: () => {},
+    onPause: () => {},
     name: '曲の名前',
     composers: [
       {

--- a/src/layouts/components/AudioControlMenu/AudioControlMenu.story.tsx
+++ b/src/layouts/components/AudioControlMenu/AudioControlMenu.story.tsx
@@ -16,6 +16,8 @@ const meta: ComponentMeta<typeof AudioControlMenu> = {
       },
     ],
     isPlaying: true,
+    duration: 622,
+    currentTime: 23,
   },
   argTypes: {
     className: {
@@ -46,6 +48,14 @@ const meta: ComponentMeta<typeof AudioControlMenu> = {
     onPause: {
       description: '再生中に再生ボタンが押されたときに呼び出されるイベントハンドラを指定できる。',
       control: { type: 'none' },
+    },
+    duration: {
+      description: '現在読み込まれている曲の長さを秒単位で指定する。',
+      control: { type: 'number' },
+    },
+    currentTime: {
+      description: '現在読み込まれている曲の再生位置を秒単位で指定する。',
+      control: { type: 'number' },
     },
   },
 };

--- a/src/layouts/components/AudioControlMenu/AudioControlMenu.story.tsx
+++ b/src/layouts/components/AudioControlMenu/AudioControlMenu.story.tsx
@@ -1,5 +1,4 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { action } from '@storybook/addon-actions';
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
 
 import { AudioControlMenu } from './index';
@@ -17,7 +16,6 @@ const meta: ComponentMeta<typeof AudioControlMenu> = {
       },
     ],
     isPlaying: true,
-    setIsPlaying: action('setIsPlaying'),
   },
   argTypes: {
     className: {
@@ -41,8 +39,12 @@ const meta: ComponentMeta<typeof AudioControlMenu> = {
       description: '現在再生中かどうか',
       control: { type: 'boolean' },
     },
-    setIsPlaying: {
-      description: '再生中かどうかを変更する関数。`isPlaying`とセットで使用する。',
+    onPlay: {
+      description: '停止中に再生ボタンが押されたときに呼び出されるイベントハンドラを指定できる。',
+      control: { type: 'none' },
+    },
+    onPause: {
+      description: '再生中に再生ボタンが押されたときに呼び出されるイベントハンドラを指定できる。',
       control: { type: 'none' },
     },
   },

--- a/src/layouts/components/AudioControlMenu/container.tsx
+++ b/src/layouts/components/AudioControlMenu/container.tsx
@@ -5,7 +5,10 @@ import { useAudioControlMenu } from './hooks/useAudioControlMenu';
 import type { AudioControlMenuProps } from './index';
 import { AudioControlMenu } from './index';
 
-export const AudioControlMenuContainer: FC<AudioControlMenuProps> = (props) => {
+export type AudioControlMenuContainerStateProps = Pick<AudioControlMenuProps, 'name' | 'composers' | 'isPlaying' | 'onPlay' | 'onPause'>;
+export type AudioControlMenuContainerProps = Omit<AudioControlMenuProps, keyof AudioControlMenuContainerStateProps>;
+
+export const AudioControlMenuContainer: FC<AudioControlMenuContainerProps> = (props) => {
   //
   // `useAudioControlMenu`を注入可能にする。
   // `production`環境ではDI関連の当該コードは`react-magnetic-di/babel-plugin`により削除される。

--- a/src/layouts/components/AudioControlMenu/container.tsx
+++ b/src/layouts/components/AudioControlMenu/container.tsx
@@ -5,7 +5,10 @@ import { useAudioControlMenu } from './hooks/useAudioControlMenu';
 import type { AudioControlMenuProps } from './index';
 import { AudioControlMenu } from './index';
 
-export type AudioControlMenuContainerStateProps = Pick<AudioControlMenuProps, 'name' | 'composers' | 'isPlaying' | 'onPlay' | 'onPause'>;
+export type AudioControlMenuContainerStateProps = Pick<
+  AudioControlMenuProps,
+  'name' | 'composers' | 'isPlaying' | 'onPlay' | 'onPause' | 'duration' | 'currentTime'
+>;
 export type AudioControlMenuContainerProps = Omit<AudioControlMenuProps, keyof AudioControlMenuContainerStateProps>;
 
 export const AudioControlMenuContainer: FC<AudioControlMenuContainerProps> = (props) => {

--- a/src/layouts/components/AudioControlMenu/formatDuration.ts
+++ b/src/layouts/components/AudioControlMenu/formatDuration.ts
@@ -1,0 +1,7 @@
+export const formatDuration = (duration: number): string => {
+  const minutes = Math.floor(duration / 60);
+  const seconds = Math.floor(duration % 60);
+  const minutesString = minutes.toString().padStart(1, '0');
+  const secondsString = seconds.toString().padStart(2, '0');
+  return `${minutesString}:${secondsString}`;
+};

--- a/src/layouts/components/AudioControlMenu/hooks/useAudioControlMenu.ts
+++ b/src/layouts/components/AudioControlMenu/hooks/useAudioControlMenu.ts
@@ -7,7 +7,7 @@ export const useAudioControlMenu = (): AudioControlMenuContainerStateProps => {
   const audioResource = useAudioResourceValue();
   const name = audioResource?.name || '曲が選ばれていません';
   const composers = audioResource?.composers || [];
-  const { isPlaying } = useAudioControlValue();
+  const { isPlaying, duration, currentTime } = useAudioControlValue();
 
   const audio = useAudioRefReadOnly();
   //
@@ -22,6 +22,8 @@ export const useAudioControlMenu = (): AudioControlMenuContainerStateProps => {
     name,
     composers,
     isPlaying,
+    duration,
+    currentTime,
     onPlay,
     onPause,
   };

--- a/src/layouts/components/AudioControlMenu/hooks/useAudioControlMenu.ts
+++ b/src/layouts/components/AudioControlMenu/hooks/useAudioControlMenu.ts
@@ -1,16 +1,28 @@
-import type { AudioControlMenuStateProps } from '../index';
+import type { AudioControlMenuContainerStateProps } from '../container';
 import { useAudioControlValue } from '@/state/audio/audioControl';
+import { useAudioRefReadOnly } from '@/state/audio/audioRefReadOnly';
 import { useAudioResourceValue } from '@/state/audio/audioResource';
 
-export const useAudioControlMenu = (): AudioControlMenuStateProps => {
+export const useAudioControlMenu = (): AudioControlMenuContainerStateProps => {
   const audioResource = useAudioResourceValue();
   const name = audioResource?.name || '曲が選ばれていません';
   const composers = audioResource?.composers || [];
-  const { isPlaying, setIsPlaying } = useAudioControlValue();
+  const { isPlaying } = useAudioControlValue();
+
+  const audio = useAudioRefReadOnly();
+  //
+  // TypeError: Failed to execute 'play' on 'HTMLMediaElement': Illegal invocation
+  // `HTMLMediaElement`付属のメソッドは`this`がその`HTMLMediaElement`でないとエラーになるから、レキシカルスコープを使って束縛する
+  // (無名関数で囲む)
+  //
+  const onPlay = () => audio?.play() || (() => {});
+  const onPause = () => audio?.pause() || (() => {});
+
   return {
     name,
     composers,
     isPlaying,
-    setIsPlaying,
+    onPlay,
+    onPause,
   };
 };

--- a/src/layouts/components/AudioControlMenu/index.tsx
+++ b/src/layouts/components/AudioControlMenu/index.tsx
@@ -9,15 +9,20 @@ import twMerge from '@/libs/twmerge';
 import type { AudioControl } from '@/state/audio/audioControl';
 import type { AudioResource } from '@/state/audio/audioResource';
 
-export type AudioControlMenuProps = Pick<ButtonProps, 'className'> & Pick<NavigationMenuProps, 'viewportClassName'>;
+export type AudioControlMenuProps = Pick<ButtonProps, 'className'> &
+  Pick<NavigationMenuProps, 'viewportClassName'> &
+  Pick<AudioResource, 'name' | 'composers'> &
+  Pick<AudioControl, 'isPlaying'> & {
+    onPlay: () => void;
+    onPause: () => void;
+  };
 
-export type AudioControlMenuStateProps = Pick<AudioControl, 'isPlaying' | 'setIsPlaying'> & Pick<AudioResource, 'name' | 'composers'>;
-
-export const AudioControlMenu: FC<AudioControlMenuProps & AudioControlMenuStateProps> = ({
+export const AudioControlMenu: FC<AudioControlMenuProps> = ({
   name,
   composers,
   isPlaying,
-  setIsPlaying,
+  onPlay,
+  onPause,
   viewportClassName,
   className,
   ...props
@@ -46,7 +51,18 @@ export const AudioControlMenu: FC<AudioControlMenuProps & AudioControlMenuStateP
           </div>
         </div>
         <div>
-          <Button className="text-neutral-500" onClick={() => setIsPlaying(!isPlaying)} circle outlined>
+          <Button
+            className="text-neutral-500"
+            onClick={() => {
+              if (isPlaying) {
+                onPause();
+              } else {
+                onPlay();
+              }
+            }}
+            circle
+            outlined
+          >
             <ButtonIcon>{isPlaying ? <BsPauseFill /> : <BsPlayFill />}</ButtonIcon>
           </Button>
         </div>

--- a/src/layouts/components/AudioControlMenu/index.tsx
+++ b/src/layouts/components/AudioControlMenu/index.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { BsPauseFill, BsPlayFill } from 'react-icons/bs';
 import { HiMusicNote } from 'react-icons/hi';
+import { formatDuration } from './formatDuration';
 import { Button, ButtonProps, ButtonIcon } from '@/components/Button';
 import { Link } from '@/components/Link';
 import { NavigationMenu, NavigationMenuProps, NavigationItem, NavigationTrigger, NavigationContent, NavigationLink } from '@/components/Navigation';
@@ -12,7 +13,7 @@ import type { AudioResource } from '@/state/audio/audioResource';
 export type AudioControlMenuProps = Pick<ButtonProps, 'className'> &
   Pick<NavigationMenuProps, 'viewportClassName'> &
   Pick<AudioResource, 'name' | 'composers'> &
-  Pick<AudioControl, 'isPlaying'> & {
+  Pick<AudioControl, 'isPlaying' | 'duration' | 'currentTime'> & {
     onPlay: () => void;
     onPause: () => void;
   };
@@ -21,6 +22,8 @@ export const AudioControlMenu: FC<AudioControlMenuProps> = ({
   name,
   composers,
   isPlaying,
+  duration,
+  currentTime,
   onPlay,
   onPause,
   viewportClassName,
@@ -50,6 +53,7 @@ export const AudioControlMenu: FC<AudioControlMenuProps> = ({
             ))}
           </div>
         </div>
+        <p className="text-xs text-neutral-500">{`${formatDuration(currentTime)} / ${formatDuration(duration)}`}</p>
         <div>
           <Button
             className="text-neutral-500"

--- a/src/layouts/components/AudioControlMenu/index.tsx
+++ b/src/layouts/components/AudioControlMenu/index.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { useMemo } from 'react';
 import { BsPauseFill, BsPlayFill } from 'react-icons/bs';
 import { HiMusicNote } from 'react-icons/hi';
 import { formatDuration } from './formatDuration';
@@ -29,48 +30,51 @@ export const AudioControlMenu: FC<AudioControlMenuProps> = ({
   viewportClassName,
   className,
   ...props
-}) => (
-  <NavigationMenu viewportClassName={twMerge('left-0 justify-start min-w-[24rem]', viewportClassName)}>
-    <NavigationItem>
-      <NavigationTrigger>
-        <Button className={twMerge('p-0 min-h-12 ', className)} ghost circle aria-label="音楽プレイヤーを開く" {...props}>
-          {/* TODO: ここに音楽の波形に合わせたスペクトラムを挿入する */}
-          <ButtonIcon>
-            <HiMusicNote />
-          </ButtonIcon>
-        </Button>
-      </NavigationTrigger>
-      <NavigationContent className="w-auto items-center gap-2 p-6">
-        <div className={twMerge('flex flex-row items-baseline justify-between gap-4', composers.length > 1 && 'items-center')}>
-          <h1 className="font-branding text-3xl font-bold">{name}</h1>
-          <div className="flex flex-col-reverse items-start justify-start gap-0">
-            {composers.map((composer) => (
-              <NavigationLink key={composer.name}>
-                <Link className="font-normal text-neutral-500" href={composer.social || '#'}>
-                  {composer.name}
-                </Link>
-              </NavigationLink>
-            ))}
-          </div>
-        </div>
-        <p className="text-xs text-neutral-500">{`${formatDuration(currentTime)} / ${formatDuration(duration)}`}</p>
-        <div>
-          <Button
-            className="text-neutral-500"
-            onClick={() => {
-              if (isPlaying) {
-                onPause();
-              } else {
-                onPlay();
-              }
-            }}
-            circle
-            outlined
-          >
-            <ButtonIcon>{isPlaying ? <BsPauseFill /> : <BsPlayFill />}</ButtonIcon>
+}) => {
+  const formattedTimeDisplay = useMemo(() => `${formatDuration(currentTime)} / ${formatDuration(duration)}`, [currentTime, duration]);
+  return (
+    <NavigationMenu viewportClassName={twMerge('left-0 justify-start min-w-[24rem]', viewportClassName)}>
+      <NavigationItem>
+        <NavigationTrigger>
+          <Button className={twMerge('p-0 min-h-12 ', className)} ghost circle aria-label="音楽プレイヤーを開く" {...props}>
+            {/* TODO: ここに音楽の波形に合わせたスペクトラムを挿入する */}
+            <ButtonIcon>
+              <HiMusicNote />
+            </ButtonIcon>
           </Button>
-        </div>
-      </NavigationContent>
-    </NavigationItem>
-  </NavigationMenu>
-);
+        </NavigationTrigger>
+        <NavigationContent className="w-auto items-center gap-2 p-6">
+          <div className={twMerge('flex flex-row items-baseline justify-between gap-4', composers.length > 1 && 'items-center')}>
+            <h1 className="font-branding text-3xl font-bold">{name}</h1>
+            <div className="flex flex-col-reverse items-start justify-start gap-0">
+              {composers.map((composer) => (
+                <NavigationLink key={composer.name}>
+                  <Link className="font-normal text-neutral-500" href={composer.social || '#'}>
+                    {composer.name}
+                  </Link>
+                </NavigationLink>
+              ))}
+            </div>
+          </div>
+          <p className="text-xs text-neutral-500">{formattedTimeDisplay}</p>
+          <div>
+            <Button
+              className="text-neutral-500"
+              onClick={() => {
+                if (isPlaying) {
+                  onPause();
+                } else {
+                  onPlay();
+                }
+              }}
+              circle
+              outlined
+            >
+              <ButtonIcon>{isPlaying ? <BsPauseFill /> : <BsPlayFill />}</ButtonIcon>
+            </Button>
+          </div>
+        </NavigationContent>
+      </NavigationItem>
+    </NavigationMenu>
+  );
+};

--- a/src/layouts/components/AudioProvider/AudioProvider.story.tsx
+++ b/src/layouts/components/AudioProvider/AudioProvider.story.tsx
@@ -1,4 +1,5 @@
 import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
 
 import { AudioProvider } from './index';
 import { audioResources } from '@/state/audio/audioResource';
@@ -7,6 +8,7 @@ type Story = ComponentStoryObj<typeof AudioProvider>;
 
 const meta: ComponentMeta<typeof AudioProvider> = {
   component: AudioProvider,
+  decorators: [(story) => <RecoilRoot>{story()}</RecoilRoot>],
   argTypes: {
     children: {
       description: '子要素を指定します。',

--- a/src/layouts/components/AudioProvider/AudioProvider.story.tsx
+++ b/src/layouts/components/AudioProvider/AudioProvider.story.tsx
@@ -1,0 +1,29 @@
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { AudioProvider } from './index';
+import { audioResources } from '@/state/audio/audioResource';
+
+type Story = ComponentStoryObj<typeof AudioProvider>;
+
+const meta: ComponentMeta<typeof AudioProvider> = {
+  component: AudioProvider,
+  argTypes: {
+    children: {
+      description: '子要素を指定します。',
+      control: { type: 'none' },
+    },
+    audioResource: {
+      description: '再生する曲の情報を表す`AudioResource`オブジェクトを指定します。',
+      control: { type: 'object' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    audioResource: audioResources[0],
+  },
+  render: (args) => <AudioProvider {...args} />,
+};

--- a/src/layouts/components/AudioProvider/AudioProviderContainer.story.tsx
+++ b/src/layouts/components/AudioProvider/AudioProviderContainer.story.tsx
@@ -1,0 +1,25 @@
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
+
+import { AudioProviderContainer } from './container';
+import { AudioControlMenuContainer } from '@/layouts/components/AudioControlMenu/container';
+
+type Story = ComponentStoryObj<typeof AudioProviderContainer>;
+
+const meta: ComponentMeta<typeof AudioProviderContainer> = {
+  component: AudioProviderContainer,
+  decorators: [(story) => <RecoilRoot>{story()}</RecoilRoot>],
+  argTypes: {
+    children: {
+      description: '子要素を指定します。',
+      control: { type: 'none' },
+    },
+  },
+  args: {
+    children: <AudioControlMenuContainer />,
+  },
+};
+
+export default meta;
+
+export const WithUI: Story = {};

--- a/src/layouts/components/AudioProvider/container.tsx
+++ b/src/layouts/components/AudioProvider/container.tsx
@@ -1,0 +1,14 @@
+import type { FC } from 'react';
+import type { AudioProviderProps } from '.';
+import { AudioProvider } from '.';
+import { useAudioResourceValue, useAutoSetAudioResource } from '@/state/audio/audioResource';
+
+export type AudioProviderContainerProps = Omit<AudioProviderProps, 'audioResource'>;
+
+export const AudioProviderContainer: FC<AudioProviderContainerProps> = (props) => {
+  const audioResource = useAudioResourceValue();
+
+  // ルーターのパスに合わせてAudioResourceの値を自動設定する
+  useAutoSetAudioResource();
+  return <AudioProvider audioResource={audioResource} {...props} />;
+};

--- a/src/layouts/components/AudioProvider/index.tsx
+++ b/src/layouts/components/AudioProvider/index.tsx
@@ -1,0 +1,101 @@
+import type { FC, ReactEventHandler, ReactNode } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
+import { useSetAudioControl } from '@/state/audio/audioControl';
+import type { AudioRef } from '@/state/audio/audioRefReadOnly';
+import { AudioRefReadOnlyContext } from '@/state/audio/audioRefReadOnly';
+
+import type { AudioResource } from '@/state/audio/audioResource';
+
+export type AudioProviderProps = {
+  audioResource?: AudioResource;
+  children: ReactNode;
+};
+
+export const AudioProvider: FC<AudioProviderProps> = ({ audioResource, children }) => {
+  const [audioRefState, setAudioRefState] = useState<AudioRef | null>(null);
+  const audioRef = useRef<AudioRef>(null);
+
+  // `Context`で公開する`audioRef`の値を更新する
+  useEffect(() => {
+    setAudioRefState(audioRef.current);
+  }, [audioRef, setAudioRefState, audioResource]);
+
+  // React側で管理されていない(`uncontrolled`)な内部の`<audio>`タグの状態をRecoilのAtom`AudioControl`の状態に反映する`InnerStatePropagator`を定義する
+  const setAudioControlValue = useSetAudioControl();
+  const onPlayInnerStatePropagator = useCallback(() => {
+    setAudioControlValue((prev) => ({
+      ...prev,
+      isPlaying: true,
+    }));
+  }, [setAudioControlValue]);
+  const onPauseInnerStatePropagator = useCallback(() => {
+    setAudioControlValue((prev) => ({
+      ...prev,
+      isPlaying: false,
+    }));
+  }, [setAudioControlValue]);
+  const onDurationChangeInnerStatePropagator = useCallback<ReactEventHandler<HTMLAudioElement>>(
+    (event) => {
+      if (event.target === null) return;
+      if (!(event.target instanceof HTMLAudioElement)) return;
+      const { duration } = event.target;
+      setAudioControlValue((prev) => ({
+        ...prev,
+        duration,
+      }));
+    },
+    [setAudioControlValue],
+  );
+  //
+  // このイベントの発火頻度は、パフォーマンスに影響を与えない程度に自動調整される e.g. 4Hz ~ 66Hz
+  // 参照: https://developer.mozilla.org/ja/docs/Web/API/HTMLMediaElement/timeupdate_event
+  //
+  const onTimeUpdateInnerStatePropagator = useCallback<ReactEventHandler<HTMLAudioElement>>(
+    (event) => {
+      if (event.target === null) return;
+      if (!(event.target instanceof HTMLAudioElement)) return;
+      const { duration } = event.target;
+      setAudioControlValue((prev) => ({
+        ...prev,
+        duration,
+      }));
+    },
+    [setAudioControlValue],
+  );
+  const onVolumeChangeInnerStatePropagator = useCallback<ReactEventHandler<HTMLAudioElement>>(
+    (event) => {
+      if (event.target === null) return;
+      if (!(event.target instanceof HTMLAudioElement)) return;
+      const { volume } = event.target;
+      setAudioControlValue((prev) => ({
+        ...prev,
+        volume,
+      }));
+    },
+    [setAudioControlValue],
+  );
+
+  return (
+    <AudioRefReadOnlyContext.Provider value={audioRefState}>
+      {/* TODO: 曲に対応する適切なWebVTTキャプションファイルを、余裕がある時に作成して追加する */}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <audio
+        autoPlay={!!audioResource}
+        preload="auto"
+        loop
+        ref={audioRef}
+        src={audioResource?.src}
+        key={audioResource?.src}
+        onPlay={onPlayInnerStatePropagator}
+        onPause={onPauseInnerStatePropagator}
+        onDurationChange={onDurationChangeInnerStatePropagator}
+        onTimeUpdate={onTimeUpdateInnerStatePropagator}
+        onVolumeChange={onVolumeChangeInnerStatePropagator}
+      />
+      {children}
+    </AudioRefReadOnlyContext.Provider>
+  );
+};
+AudioProvider.defaultProps = {
+  audioResource: undefined,
+};

--- a/src/layouts/components/AudioProvider/index.tsx
+++ b/src/layouts/components/AudioProvider/index.tsx
@@ -99,12 +99,14 @@ export const AudioProvider: FC<AudioProviderProps> = ({ audioResource, children 
   const onDocumentInteractEventListener = useCallback(() => {
     pseudoAutoPlayAudio();
     window.document.removeEventListener('click', onDocumentInteractEventListener);
+    window.document.removeEventListener('scroll', onDocumentInteractEventListener);
   }, [pseudoAutoPlayAudio]);
 
   useEffect(() => {
     if (hasAutoPlaySuceeded) return;
     if (!(window && window.document)) return;
     window.document.addEventListener('click', onDocumentInteractEventListener);
+    window.document.addEventListener('scroll', onDocumentInteractEventListener);
   }, [onDocumentInteractEventListener, pseudoAutoPlayAudio, hasAutoPlaySuceeded]);
 
   return (

--- a/src/layouts/components/AudioProvider/index.tsx
+++ b/src/layouts/components/AudioProvider/index.tsx
@@ -55,10 +55,10 @@ export const AudioProvider: FC<AudioProviderProps> = ({ audioResource, children 
     (event) => {
       if (event.target === null) return;
       if (!(event.target instanceof HTMLAudioElement)) return;
-      const { duration } = event.target;
+      const { currentTime } = event.target;
       setAudioControlValue((prev) => ({
         ...prev,
-        duration,
+        currentTime,
       }));
     },
     [setAudioControlValue],

--- a/src/layouts/components/AudioProvider/index.tsx
+++ b/src/layouts/components/AudioProvider/index.tsx
@@ -99,14 +99,12 @@ export const AudioProvider: FC<AudioProviderProps> = ({ audioResource, children 
   const onDocumentInteractEventListener = useCallback(() => {
     pseudoAutoPlayAudio();
     window.document.removeEventListener('click', onDocumentInteractEventListener);
-    window.document.removeEventListener('scroll', onDocumentInteractEventListener);
   }, [pseudoAutoPlayAudio]);
 
   useEffect(() => {
     if (hasAutoPlaySuceeded) return;
     if (!(window && window.document)) return;
     window.document.addEventListener('click', onDocumentInteractEventListener);
-    window.document.addEventListener('scroll', onDocumentInteractEventListener);
   }, [onDocumentInteractEventListener, pseudoAutoPlayAudio, hasAutoPlaySuceeded]);
 
   return (

--- a/src/layouts/components/Header/Header.story.tsx
+++ b/src/layouts/components/Header/Header.story.tsx
@@ -16,7 +16,8 @@ const injectedHooks = [
   })),
   injectable(useAudioControlMenu, () => ({
     isPlaying: false,
-    setIsPlaying: () => {},
+    onPlay: () => {},
+    onPause: () => {},
     name: '曲の名前',
     composers: [
       {

--- a/src/layouts/components/Header/Header.story.tsx
+++ b/src/layouts/components/Header/Header.story.tsx
@@ -24,6 +24,8 @@ const injectedHooks = [
         name: '作曲者名',
       },
     ],
+    duration: 100,
+    currentTime: 0,
   })),
 ];
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app';
 import type { FC } from 'react';
 import { RecoilRoot } from 'recoil';
 import { Provider } from 'urql';
+import { AudioProviderContainer } from '@/layouts/components/AudioProvider/container';
 import urqlClient from '@/libs/urql';
 import authActions from '@/state/authState';
 import 'tailwindcss/tailwind.css';
@@ -17,7 +18,9 @@ const CustomApp: FC<AppProps> = ({ Component, pageProps }) => (
   <RecoilRoot>
     <AppInit />
     <Provider value={urqlClient}>
-      <Component {...pageProps} />
+      <AudioProviderContainer>
+        <Component {...pageProps} />
+      </AudioProviderContainer>
     </Provider>
   </RecoilRoot>
 );

--- a/src/state/audio/audioAutoPlay.tsx
+++ b/src/state/audio/audioAutoPlay.tsx
@@ -1,0 +1,25 @@
+import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
+import { atomKeys } from '../recoilKeys';
+
+export type AudioAutoPlay = {
+  shouldAutoPlay: boolean;
+  hasAutoPlaySuceeded: boolean;
+};
+
+const AudioAutoPlayState = atom<AudioAutoPlay>({
+  key: atomKeys.AUDIO_AUTOPLAY,
+  default: {
+    shouldAutoPlay: true,
+    hasAutoPlaySuceeded: false,
+  },
+});
+
+export const useAudioAutoPlayStateValue = () => {
+  const audioControl = useRecoilValue(AudioAutoPlayState);
+  return audioControl;
+};
+
+export const useSetAudioAutoPlayState = () => {
+  const setAudioControl = useSetRecoilState(AudioAutoPlayState);
+  return setAudioControl;
+};

--- a/src/state/audio/audioControl.tsx
+++ b/src/state/audio/audioControl.tsx
@@ -6,7 +6,6 @@ export type AudioControl = {
   currentTime: number;
   duration: number;
   volume: number;
-  hasAutoPlaySuceeded: boolean;
 };
 
 const AudioControlState = atom<AudioControl>({
@@ -16,7 +15,6 @@ const AudioControlState = atom<AudioControl>({
     currentTime: 0,
     duration: 0,
     volume: 0,
-    hasAutoPlaySuceeded: false,
   },
 });
 

--- a/src/state/audio/audioControl.tsx
+++ b/src/state/audio/audioControl.tsx
@@ -3,22 +3,20 @@ import { atomKeys } from '../recoilKeys';
 
 export type AudioControl = {
   isPlaying: boolean;
+  currentTime: number;
+  duration: number;
   volume: number;
-  isMuted: boolean;
-  setIsPlaying: (isPlaying: boolean) => void;
-  setVolume: (volume: number) => void;
-  setIsMuted: (isMuted: boolean) => void;
+  hasAutoPlaySuceeded: boolean;
 };
 
 const AudioControlState = atom<AudioControl>({
   key: atomKeys.AUDIO_CONTROL,
   default: {
     isPlaying: false,
+    currentTime: 0,
+    duration: 0,
     volume: 0,
-    isMuted: false,
-    setIsPlaying: () => {},
-    setVolume: () => {},
-    setIsMuted: () => {},
+    hasAutoPlaySuceeded: false,
   },
 });
 

--- a/src/state/audio/audioRefReadOnly.tsx
+++ b/src/state/audio/audioRefReadOnly.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export type AudioRef = HTMLAudioElement;
+
+//
+// UIで表示する残り時間等はRecoilのAtom`AudioControl`を介して参照するようにする。
+// `ref.current.play()`等の操作用の関数の呼び出しのみに使用することが好ましい。
+// そのことを示すために、名前に`ReadOnly`をつけている。
+//
+export const AudioRefReadOnlyContext = createContext<AudioRef | null>(null);
+
+export const useAudioRefReadOnly = () => {
+  const audioRef = useContext(AudioRefReadOnlyContext);
+  return audioRef;
+};

--- a/src/state/audio/audioResource.tsx
+++ b/src/state/audio/audioResource.tsx
@@ -21,23 +21,23 @@ export type AudioResource = {
 // NOTE: 配列の番号が小さいほうがより優先される実装にする
 export const audioResources: Array<AudioResource> = [
   {
-    name: '*素晴らしい曲名ゲーム*',
+    name: '栄の活躍:Games',
     composers: [
       {
-        name: '*作曲者様の名前*',
+        name: '酒井晴渚',
       },
     ],
-    src: 'https://example.com/audio.mp3',
-    target: /^\/games[\w-/]*$/,
+    src: '/audio/sakae-remix.mp3',
+    target: /^\/games\/[\w-/]*$/,
   },
   {
-    name: '*素晴らしい曲名デフォルト*',
+    name: '栄の活躍:Remix',
     composers: [
       {
-        name: '*作曲者様の名前*',
+        name: '酒井晴渚',
       },
     ],
-    src: 'https://example.com/audio.mp3',
+    src: '/audio/sakae-remix.mp3',
     target: /^\/[\w-/]*$/,
   },
 ];

--- a/src/state/recoilKeys.ts
+++ b/src/state/recoilKeys.ts
@@ -3,6 +3,7 @@ const atomKeys = {
   AUDIO_RESOURCE: 'audioResource',
   AUDIO_RESOURCE_AUTO_SET_PERMISSION: 'audioResourceAutoSetPermission',
   AUDIO_CONTROL: 'audioControl',
+  AUDIO_AUTOPLAY: 'audioAutoplay',
 } as const;
 
 const selectorKeys = {


### PR DESCRIPTION
- close #184

# Todo
- 自動再生失敗時に、RecoilのAtom`AudioControl`のメンバ`hasAutoPlaySuceeded`に対応した値を設定する
- 自動再生失敗時に、ユーザーのインタラクト`e.g. 画面のタッチ`などにあわせて再生開始をできるようにする

# 概要
実際にVercelのDeployを開いてみて曲を再生できるか試してみてください。
自動再生は制約的に実現不可能なのですが、ユーザーのインタラクト`e.g. 画面のタッチ`などにあわせて再生開始をすることはできるので、がんばります。(この機能は未実装です)
現在のパスに合わせて、自動で対応した曲の情報を解決して、RecoilのAtom`AudioResource`を介してUIに反映できている様子
![image](https://user-images.githubusercontent.com/16751535/194593139-6b9dda79-5522-427e-8742-c22b666a0cf3.png)
