### PR TITLE
fix: 🚑️ (style/stylesheet/global.scss) ページ全体が横にはみ出した要素を描画しないように変更した。

### DIFF
--- a/src/presentation/style/stylesheet/global.scss
+++ b/src/presentation/style/stylesheet/global.scss
@@ -4,6 +4,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: Inter, 'Noto Sans JP', sans-serif;
+  overflow-x: hidden;
 }
 
 #__next {


### PR DESCRIPTION
- close #224 

`w-screen (100vw)`がスクロールバーの占拠分を考慮しない問題への応急措置として変更した。