### PR TITLE
`<Layout>`にFirebaseで認証済みでなおかつ登録が済んでいないときにのみ表示されるモーダルを追加した。他修正

### DIFF
--- a/src/presentation/layout/component/signup-progress-notification-modal/hook/use-signup-progress-notification-modal.hook.ts
+++ b/src/presentation/layout/component/signup-progress-notification-modal/hook/use-signup-progress-notification-modal.hook.ts
@@ -1,8 +1,7 @@
 import { useRouter } from 'next/router';
 import { useState, useMemo, useEffect } from 'react';
 import type { SignupProgressNotificationModalProps } from '../signup-progress-notification-modal.presenter';
-import { useCheckUserExistanceUseCase } from '@/use-case/user/use-check-user-existance.use-case';
-import { useCurrentUserIdUseCase } from '@/use-case/user/use-current-user-id.use-case';
+import { useCurrentUserAuthenticationStatusUseCase } from '@/use-case/user/use-current-user-authentication-status.use-case';
 
 const authPagePathnameRegExp = /^\/auth(\/.+|)/; // `/auth`以下のすべてのパスにマッチする正規表現
 
@@ -18,12 +17,8 @@ export const useSignupProgressNotificationModal = (): Pick<SignupProgressNotific
 
   const { pathname } = useRouter();
   const isCurrentlyAtAuthPage = useMemo(() => authPagePathnameRegExp.test(pathname), [pathname]);
-  const currentUser = useCurrentUserIdUseCase(); // Firebase Authの認証情報由来のid
-  const hasUserAuthenticated = useMemo(() => !!currentUser, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか
-  // ユーザーが各種情報を登録済みかどうか
-  const hasUserRegisteredInfo = useCheckUserExistanceUseCase({
-    id: currentUser?.id,
-  });
+  const { hasUserAuthenticated, hasUserRegisteredInfo } = useCurrentUserAuthenticationStatusUseCase();
+
   const shouldShowModal = useMemo(() => {
     if (!hasComponentMounted) return false; // Hydrationが失敗しないようにするため
     return hasUserAuthenticated && !hasUserRegisteredInfo && !isCurrentlyAtAuthPage;

--- a/src/presentation/layout/component/signup-progress-notification-modal/hook/use-signup-progress-notification-modal.hook.ts
+++ b/src/presentation/layout/component/signup-progress-notification-modal/hook/use-signup-progress-notification-modal.hook.ts
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router';
+import { useState, useMemo, useEffect } from 'react';
+import type { SignupProgressNotificationModalProps } from '../signup-progress-notification-modal.presenter';
+import { useCheckUserExistanceUseCase } from '@/use-case/user/use-check-user-existance.use-case';
+import { useCurrentUserIdUseCase } from '@/use-case/user/use-current-user-id.use-case';
+
+const authPagePathnameRegExp = /^\/auth(\/.+|)/; // `/auth`以下のすべてのパスにマッチする正規表現
+
+export const useSignupProgressNotificationModal = (): Pick<SignupProgressNotificationModalProps, 'open'> => {
+  //
+  // コンポーネントがマウントされた後にのみログイン状態から計算された値を使用するようにしないと、SSRのものと差異が生じてHydrationに失敗してしまう
+  // 参照: https://nextjs.org/docs/messages/react-hydration-error
+  //
+  const [hasComponentMounted, setHasComponentMounted] = useState(false);
+  useEffect(() => {
+    setHasComponentMounted(true);
+  }, []);
+
+  const { pathname } = useRouter();
+  const isCurrentlyAtAuthPage = useMemo(() => authPagePathnameRegExp.test(pathname), [pathname]);
+  const currentUser = useCurrentUserIdUseCase(); // Firebase Authの認証情報由来のid
+  const hasUserAuthenticated = useMemo(() => !!currentUser, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか
+  // ユーザーが各種情報を登録済みかどうか
+  const hasUserRegisteredInfo = useCheckUserExistanceUseCase({
+    id: currentUser?.id,
+  });
+  const shouldShowModal = useMemo(() => {
+    if (!hasComponentMounted) return false; // Hydrationが失敗しないようにするため
+    return hasUserAuthenticated && !hasUserRegisteredInfo && !isCurrentlyAtAuthPage;
+  }, [hasUserAuthenticated, hasUserRegisteredInfo, isCurrentlyAtAuthPage, hasComponentMounted]);
+  return {
+    open: shouldShowModal,
+  };
+};

--- a/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.container.tsx
+++ b/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.container.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react';
+import { di } from 'react-magnetic-di';
+import { useSignupProgressNotificationModal } from './hook/use-signup-progress-notification-modal.hook';
+import { SignupProgressNotificationModal } from './signup-progress-notification-modal.presenter';
+
+export const SignUpProgressNotificationModalContainer: FC = () => {
+  di(useSignupProgressNotificationModal);
+  const states = useSignupProgressNotificationModal();
+  return <SignupProgressNotificationModal {...states} />;
+};

--- a/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.presenter.tsx
+++ b/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.presenter.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import type { FC } from 'react';
+import { Button } from '@/presentation/primitive/component/button/button.presenter';
+import {
+  Modal,
+  ModalTitle,
+  ModalDescription,
+  ModalOverlay,
+  ModalContent,
+  ModalButtonGroup,
+} from '@/presentation/primitive/component/modal/modal.presenter';
+import type { ModalProps } from '@/presentation/primitive/component/modal/modal.presenter';
+
+export type SignupProgressNotificationModalProps = Pick<ModalProps, 'open' | 'onOpenChange'>;
+
+export const SignupProgressNotificationModal: FC<SignupProgressNotificationModalProps> = ({ open, onOpenChange }) => (
+  <Modal open={open} onOpenChange={onOpenChange}>
+    <ModalOverlay>
+      <ModalContent>
+        <ModalTitle>まだ登録が完了していません！</ModalTitle>
+        <ModalDescription>
+          情報登録ページから、ニックネームや
+          <br />
+          キャラクターなどの追加の情報を入力してください
+        </ModalDescription>
+        <ModalButtonGroup>
+          <Link href="/auth/sign-out">
+            <Button outlined>サインアウトする</Button>
+          </Link>
+          <Link href="/auth/new-user">
+            <Button className="bg-gradient-to-br gradient-primary">登録ページへ</Button>
+          </Link>
+        </ModalButtonGroup>
+      </ModalContent>
+    </ModalOverlay>
+  </Modal>
+);

--- a/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.presenter.tsx
+++ b/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.presenter.tsx
@@ -14,7 +14,7 @@ import type { ModalProps } from '@/presentation/primitive/component/modal/modal.
 export type SignupProgressNotificationModalProps = Pick<ModalProps, 'open' | 'onOpenChange'>;
 
 export const SignupProgressNotificationModal: FC<SignupProgressNotificationModalProps> = ({ open, onOpenChange }) => (
-  <Modal open={open} onOpenChange={onOpenChange}>
+  <Modal defaultOpen={false} open={open} onOpenChange={onOpenChange}>
     <ModalOverlay>
       <ModalContent>
         <ModalTitle>まだ登録が完了していません！</ModalTitle>

--- a/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.story.tsx
+++ b/src/presentation/layout/component/signup-progress-notification-modal/signup-progress-notification-modal.story.tsx
@@ -1,0 +1,29 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { ComponentStoryObj, ComponentMeta } from '@storybook/react';
+
+import { SignupProgressNotificationModal } from './signup-progress-notification-modal.presenter';
+
+type Story = ComponentStoryObj<typeof SignupProgressNotificationModal>;
+
+const meta: ComponentMeta<typeof SignupProgressNotificationModal> = {
+  component: SignupProgressNotificationModal,
+  args: {
+    open: true,
+  },
+  argTypes: {
+    open: {
+      description:
+        'このモーダルの開閉状態を指定できる。**開閉を`state`で管理する必要がない場合は、指定しなくてもよい。**その場合でも、`trigger`ボタンとモーダル外クリックによる開閉は可能。',
+      control: { type: 'boolean' },
+    },
+    onOpenChange: {
+      description:
+        'このモーダルの開閉状態が変更されようとするときに実行されるイベントハンドラ関数を渡すことができる。**開閉を`state`で管理する必要がない場合は、指定しなくてもよい。**その場合でも、`trigger`ボタンとモーダル外クリックによる開閉は可能。',
+      control: { type: 'function' },
+    },
+  },
+};
+
+export default meta;
+
+export const Default: Story = {};

--- a/src/presentation/layout/layout.container.tsx
+++ b/src/presentation/layout/layout.container.tsx
@@ -2,6 +2,7 @@ import type { FC, ReactNode, ComponentPropsWithoutRef } from 'react';
 import { CommonMeta, CommonMetaProps } from './component/common-meta/common-meta.presenter';
 import { Footer } from './component/footer/footer.presenter';
 import { Header } from './component/header/header.presenter';
+import { SignUpProgressNotificationModalContainer } from './component/signup-progress-notification-modal/signup-progress-notification-modal.container';
 import twMerge from '@/presentation/style/twmerge';
 
 export type LayoutProps = ComponentPropsWithoutRef<'main'> &
@@ -17,5 +18,6 @@ export const Layout: FC<LayoutProps> = ({ children, title, className, ...props }
       {children}
     </main>
     <Footer className="m-0 w-full grow-0" />
+    <SignUpProgressNotificationModalContainer />
   </div>
 );

--- a/src/presentation/layout/layout.story.tsx
+++ b/src/presentation/layout/layout.story.tsx
@@ -5,6 +5,7 @@ import { RecoilRoot } from 'recoil';
 
 import { Layout } from './layout.container';
 import { useAudioControlMenu } from '@/presentation/layout/component/audio-control-menu/hook/use-audio-control-menu.hook';
+import { useSignupProgressNotificationModal } from '@/presentation/layout/component/signup-progress-notification-modal/hook/use-signup-progress-notification-modal.hook';
 import { useUserNavigationMenu } from '@/presentation/layout/component/user-navigation-menu/hook/use-user-navigation-menu.hook';
 
 type Story = ComponentStoryObj<typeof Layout>;
@@ -27,6 +28,9 @@ const injectedHooks = [
     ],
     duration: 100,
     currentTime: 0,
+  })),
+  injectable(useSignupProgressNotificationModal, () => ({
+    open: false,
   })),
 ];
 

--- a/src/presentation/primitive/component/modal/modal.presenter.tsx
+++ b/src/presentation/primitive/component/modal/modal.presenter.tsx
@@ -72,14 +72,18 @@ export const ModalOverlay: FC<ModalOverlayProps> = ({ className, children, ...pr
 );
 
 export type ModalProps = Pick<ComponentPropsWithoutRef<typeof Dialog.Root>, 'open' | 'onOpenChange'> & {
-  trigger: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
+  trigger?: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
   children: ReactElement<ModalOverlayProps>;
 };
 
 // モーダルのトリガーとなるボタンとモーダルの中身を受け取り、モーダルを表示する本体となるコンポーネント
 export const Modal: FC<ModalProps> = ({ open, onOpenChange, trigger, children }) => (
   <Dialog.Root open={open} onOpenChange={onOpenChange}>
-    <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
+    {trigger && <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>}
     <Dialog.Portal>{children}</Dialog.Portal>
   </Dialog.Root>
 );
+
+Modal.defaultProps = {
+  trigger: undefined,
+};

--- a/src/presentation/primitive/component/modal/modal.presenter.tsx
+++ b/src/presentation/primitive/component/modal/modal.presenter.tsx
@@ -71,7 +71,7 @@ export const ModalOverlay: FC<ModalOverlayProps> = ({ className, children, ...pr
   </Dialog.Overlay>
 );
 
-export type ModalProps = Pick<ComponentPropsWithoutRef<typeof Dialog.Root>, 'open' | 'onOpenChange'> & {
+export type ModalProps = Pick<ComponentPropsWithoutRef<typeof Dialog.Root>, 'open' | 'onOpenChange' | 'defaultOpen'> & {
   trigger?: ReactElement<ComponentPropsWithoutRef<'button'> | ButtonProps>;
   children: ReactElement<ModalOverlayProps>;
 };

--- a/src/presentation/primitive/component/modal/modal.story.tsx
+++ b/src/presentation/primitive/component/modal/modal.story.tsx
@@ -10,6 +10,10 @@ type Story = ComponentStoryObj<typeof Modal>;
 const meta: ComponentMeta<typeof Modal> = {
   component: Modal,
   argTypes: {
+    defaultOpen: {
+      description: 'このモーダルの初期状態での開閉状態を指定できる。',
+      control: { type: 'boolean' },
+    },
     open: {
       description:
         'このモーダルの開閉状態を指定できる。**開閉を`state`で管理する必要がない場合は、指定しなくてもよい。**その場合でも、`trigger`ボタンとモーダル外クリックによる開閉は可能。',

--- a/src/presentation/relevant/auth/auth.page.tsx
+++ b/src/presentation/relevant/auth/auth.page.tsx
@@ -1,5 +1,5 @@
 import Router from 'next/router';
-import { FC, useState, useMemo, useEffect } from 'react';
+import { FC, useState, useEffect } from 'react';
 import { FaTwitter } from 'react-icons/fa';
 import { FcGoogle } from 'react-icons/fc';
 import { RiUser3Fill } from 'react-icons/ri';

--- a/src/presentation/relevant/auth/auth.page.tsx
+++ b/src/presentation/relevant/auth/auth.page.tsx
@@ -8,18 +8,12 @@ import { Card } from '../../primitive/component/card/card.presenter';
 import { Link, LinkIcon } from '../../primitive/component/link/link.presenter';
 import { loginWithGoogle } from '@/infra/firebase/auth';
 import { Modal, ModalTitle, ModalDescription, ModalOverlay, ModalContent } from '@/presentation/primitive/component/modal/modal.presenter';
-import { useCheckUserExistanceUseCase } from '@/use-case/user/use-check-user-existance.use-case';
-import { useCurrentUserIdUseCase } from '@/use-case/user/use-current-user-id.use-case';
+import { useCurrentUserAuthenticationStatusUseCase } from '@/use-case/user/use-current-user-authentication-status.use-case';
 
 export const Auth: FC = () => {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [shouldShowErrorModal, setShouldShowErrorModal] = useState(false);
-  const currentUser = useCurrentUserIdUseCase(); // Firebase Authの認証情報由来のid
-  const hasUserAuthenticated = useMemo(() => !!currentUser, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか
-  // ユーザーが各種情報を登録済みかどうか
-  const hasUserRegisteredInfo = useCheckUserExistanceUseCase({
-    id: currentUser?.id,
-  });
+  const { hasUserAuthenticated, hasUserRegisteredInfo } = useCurrentUserAuthenticationStatusUseCase();
   useEffect(() => {
     if (hasUserAuthenticated) {
       if (hasUserRegisteredInfo) {

--- a/src/use-case/user/use-current-user-authentication-status.use-case.ts
+++ b/src/use-case/user/use-current-user-authentication-status.use-case.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useCheckUserExistanceUseCase } from '@/use-case/user/use-check-user-existance.use-case';
+import { useCurrentUserIdUseCase } from '@/use-case/user/use-current-user-id.use-case';
+
+export type UseCurrentUserAuthenticationStatusUseCaseResult = {
+  hasUserAuthenticated: boolean;
+  hasUserRegisteredInfo: boolean;
+};
+
+export const useCurrentUserAuthenticationStatusUseCase = (): UseCurrentUserAuthenticationStatusUseCaseResult => {
+  const currentUser = useCurrentUserIdUseCase(); // Firebase Authの認証情報由来のid
+  const hasUserAuthenticated = useMemo<boolean>(() => !!currentUser && !!currentUser.id, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか
+  // ユーザーが各種情報を登録済みかどうか
+  const hasUserRegisteredInfo = useCheckUserExistanceUseCase({
+    id: currentUser?.id,
+  });
+  return {
+    hasUserAuthenticated,
+    hasUserRegisteredInfo,
+  };
+};


### PR DESCRIPTION
- close #237 
- close #239 

# 概要
Firebaseで認証済みかどうかの判定が正しく行われるように修正した。
```ts
// 修正前
  const hasUserAuthenticated = useMemo(() => !!currentUser, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか
// 修正後
  const hasUserAuthenticated = useMemo<boolean>(() => !!currentUser && !!currentUser.id, [currentUser]); // ユーザーがFirebase Authでログイン済みかどうか

```
以下の条件をすべて満たすときのみに、閉じることができない通知モーダルを表示する機能を`<Layout>`に追加しました。
- Firebaseでログイン済み
- DBへの情報登録がまだ
- `/auth`以下のページにいない
```ts
const shouldShowModal = useMemo(() => {
    if (!hasComponentMounted) return false; // Hydrationが失敗しないようにするため
    return hasUserAuthenticated && !hasUserRegisteredInfo && !isCurrentlyAtAuthPage;
  }, [hasUserAuthenticated, hasUserRegisteredInfo, isCurrentlyAtAuthPage, hasComponentMounted]);
```
![image](https://user-images.githubusercontent.com/16751535/196526008-1bc7516a-9976-4479-a071-2d2070f38d12.png)
