### PR TITLE
`<LiveCharacter>`をより小さくした。また、ゲーム個別ページで使われる`<GamePlayground>`内のキャラクターの大きさを、モバイルでのみ小さくした。

### DIFF
--- a/src/presentation/primitive/component/live-character/live-character.presenter.tsx
+++ b/src/presentation/primitive/component/live-character/live-character.presenter.tsx
@@ -39,7 +39,7 @@ export const LiveCharacter = forwardRef<HTMLElement, LiveCharacterProps>(({ name
       }}
       className="flex aspect-square w-full grow-0 items-center justify-center overflow-visible"
     >
-      <ol className="grid w-full shrink-0 scale-[200%] grid-cols-1 grid-rows-1">
+      <ol className="grid w-full shrink-0 scale-[150%] grid-cols-1 grid-rows-1">
         {images.map((imageUrl) => (
           <li key={imageUrl} className="relative col-span-full row-span-full">
             {/* キャラクタ画像の解像度 545 x 401, コンテナの横幅に合わせて拡大 `responsive` */}
@@ -55,7 +55,7 @@ export const LiveCharacter = forwardRef<HTMLElement, LiveCharacterProps>(({ name
         ))}
       </ol>
     </motion.div>
-    {displayName && <p className="-mt-2 text-xs">{name}</p>}
+    {displayName && <p className="relative z-10 -mt-2 rounded-base bg-white/75 px-2 backdrop-blur-md">{name}</p>}
   </motion.figure>
 ));
 

--- a/src/presentation/relevant/game/component/game-playground/game-playground.presenter.tsx
+++ b/src/presentation/relevant/game/component/game-playground/game-playground.presenter.tsx
@@ -26,7 +26,7 @@ export const GamePlayground: FC<GamePlaygroundProps> = ({ disabled, attenders, i
           imageUrl: [attender.avatarUrl, ...attender.itemLayerUrls],
         }))
         .map(({ name, imageUrl }) => (
-          <LiveCharacter key={name} name={name} images={imageUrl} />
+          <LiveCharacter className="w-24 md:w-32" key={name} name={name} images={imageUrl} />
         ))}
     </GameStatusIndicator>
     <div className="flex grow-0 flex-col items-stretch justify-start gap-1 px-4 text-start text-white lg:max-w-sm">{children}</div>


### PR DESCRIPTION
- close #268 

![image](https://user-images.githubusercontent.com/16751535/197358832-610aa00c-d0b5-4d69-b325-8c324c63c31b.png)
![image](https://user-images.githubusercontent.com/16751535/197358836-a4d43ab8-b02b-48df-a97f-ba2e5945d1c7.png)
